### PR TITLE
bool -> *bools; change DestinationConfigResponse field; JSON annotation cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the unnecessary `ConnectorsSourceMetadataResponse.LinkToErd` JSON annotation `omitempty`.
 
 ### Fixed
-- `DestinationConfigResponse` field `ConnectionType` has changed to `ConnectionMethod` to adequate the REST API response.
+- `DestinationConfigResponse` field `ConnectionType` has changed to `ConnectionMethod` to adequate to the REST API response.
 
 ## [0.1.0](https://github.com/fivetran/go-fivetran/releases/tag/v0.1.0) - 2021-07-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.1.0...HEAD)
+
+### Changed
+- All `bool` fields of the types `DestinationConfigResponse`, `ConnectorConfigResponse`, `ConnectorCreateResponse`, `ConnectorDetailsResponse`, `ConnectorModifyResponse`, `ConnectorSetupTestsResponse`, and `ConnectorsSourceMetadataResponse` are now `*bool`.
+
+### Removed
+- Removed the unnecessary `ConnectorsSourceMetadataResponse.LinkToErd` JSON annotation `omitempty`.
+
+### Fixed
+- `DestinationConfigResponse` field `ConnectionType` has changed to `ConnectionMethod` to adequate the REST API response.
 
 ## [0.1.0](https://github.com/fivetran/go-fivetran/releases/tag/v0.1.0) - 2021-07-05
 

--- a/connector_config.go
+++ b/connector_config.go
@@ -405,12 +405,12 @@ type ConnectorConfigResponse struct {
 	FTPPort                          int                                         `json:"ftp_port"`
 	FTPUser                          string                                      `json:"ftp_user"`
 	FTPPassword                      string                                      `json:"ftp_password"`
-	IsFTPS                           bool                                        `json:"is_ftps"`
+	IsFTPS                           *bool                                       `json:"is_ftps"`
 	SFTPHost                         string                                      `json:"sftp_host"`
 	SFTPPort                         int                                         `json:"sftp_port"`
 	SFTPUser                         string                                      `json:"sftp_user"`
 	SFTPPassword                     string                                      `json:"sftp_password"`
-	SFTPIsKeyPair                    bool                                        `json:"sftp_is_key_pair"`
+	SFTPIsKeyPair                    *bool                                       `json:"sftp_is_key_pair"`
 	Advertisables                    []string                                    `json:"advertisables"`
 	ReportType                       string                                      `json:"report_type"`
 	Dimensions                       []string                                    `json:"dimensions"`
@@ -452,7 +452,7 @@ type ConnectorConfigResponse struct {
 	AccessKeyID                      string                                      `json:"access_key_id"`
 	SecretKey                        string                                      `json:"secret_key"`
 	HomeFolder                       string                                      `json:"home_folder"`
-	SyncDataLocker                   bool                                        `json:"sync_data_locker"`
+	SyncDataLocker                   *bool                                       `json:"sync_data_locker"`
 	Projects                         []string                                    `json:"projects"`
 	Function                         string                                      `json:"function"`
 	Region                           string                                      `json:"region"`
@@ -472,7 +472,7 @@ type ConnectorConfigResponse struct {
 	GCSFolder                        string                                      `json:"gcs_folder"`
 	UserProfiles                     []string                                    `json:"user_profiles"`
 	ReportConfigurationIDs           []string                                    `json:"report_configuration_ids"`
-	EnableAllDimensionCombinations   bool                                        `json:"enable_all_dimension_combinations"`
+	EnableAllDimensionCombinations   *bool                                       `json:"enable_all_dimension_combinations"`
 	Instance                         string                                      `json:"instance"`
 	AWSRegionCode                    string                                      `json:"aws_region_code"`
 	Accounts                         []string                                    `json:"accounts"`
@@ -493,7 +493,7 @@ type ConnectorConfigResponse struct {
 	User                             string                                      `json:"user"`
 	IsSecure                         string                                      `json:"is_secure"`
 	Repositories                     []string                                    `json:"repositories"`
-	UseWebhooks                      bool                                        `json:"use_webhooks"`
+	UseWebhooks                      *bool                                       `json:"use_webhooks"`
 	DimensionAttributes              []string                                    `json:"dimension_attributes"`
 	Columns                          []string                                    `json:"columns"`
 	NetworkCode                      string                                      `json:"network_code"`
@@ -508,10 +508,10 @@ type ConnectorConfigResponse struct {
 	FunctionTrigger                  string                                      `json:"function_trigger"`
 	ConfigMethod                     string                                      `json:"config_method"`
 	QueryID                          string                                      `json:"query_id"`
-	UpdateConfigOnEachSync           bool                                        `json:"update_config_on_each_sync"`
+	UpdateConfigOnEachSync           *bool                                       `json:"update_config_on_each_sync"`
 	SiteURLs                         []string                                    `json:"site_urls"`
 	Path                             string                                      `json:"path"`
-	OnPremise                        bool                                        `json:"on_premise"`
+	OnPremise                        *bool                                       `json:"on_premise"`
 	AccessToken                      string                                      `json:"access_token"`
 	ViewThroughAttributionWindowSize string                                      `json:"view_through_attribution_window_size"`
 	PostClickAttributionWindowSize   string                                      `json:"post_click_attribution_window_size"`

--- a/connector_create.go
+++ b/connector_create.go
@@ -51,7 +51,7 @@ type ConnectorCreateResponse struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`
-			IsHistoricalSync bool   `json:"is_historical_sync"`
+			IsHistoricalSync *bool  `json:"is_historical_sync"`
 			Tasks            []struct {
 				Code    string `json:"code"`
 				Message string `json:"message"`

--- a/connector_details.go
+++ b/connector_details.go
@@ -33,7 +33,7 @@ type ConnectorDetailsResponse struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`
-			IsHistoricalSync bool   `json:"is_historical_sync"`
+			IsHistoricalSync *bool  `json:"is_historical_sync"`
 			Tasks            []struct {
 				Code    string `json:"code"`
 				Message string `json:"message"`

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -56,7 +56,7 @@ type ConnectorModifyResponse struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`
-			IsHistoricalSync bool   `json:"is_historical_sync"`
+			IsHistoricalSync *bool  `json:"is_historical_sync"`
 			Tasks            []struct {
 				Code    string `json:"code"`
 				Message string `json:"message"`

--- a/connector_setup_tests.go
+++ b/connector_setup_tests.go
@@ -40,7 +40,7 @@ type ConnectorSetupTestsResponse struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`
-			IsHistoricalSync bool   `json:"is_historical_sync"`
+			IsHistoricalSync *bool  `json:"is_historical_sync"`
 			Tasks            []struct {
 				Code    string `json:"code"`
 				Message string `json:"message"`

--- a/connectors_source_metadata.go
+++ b/connectors_source_metadata.go
@@ -25,7 +25,7 @@ type ConnectorsSourceMetadataResponse struct {
 			Description string `json:"description"`
 			IconURL     string `json:"icon_url"`
 			LinkToDocs  string `json:"link_to_docs"`
-			LinkToErd   string `json:"link_to_erd,omitempty"`
+			LinkToErd   string `json:"link_to_erd"`
 		} `json:"items"`
 		NextCursor string `json:"next_cursor"`
 	} `json:"data"`

--- a/destination_config.go
+++ b/destination_config.go
@@ -55,7 +55,7 @@ type DestinationConfigResponse struct {
 	Auth                 string `json:"auth"`
 	User                 string `json:"user"`
 	Password             string `json:"password"`
-	ConnectionType       string `json:"connection_type"`
+	ConnectionType       string `json:"connection_method"` // REST API returns "connection_method"
 	TunnelHost           string `json:"tunnel_host"`
 	TunnelPort           string `json:"tunnel_port"`
 	TunnelUser           string `json:"tunnel_user"`

--- a/destination_config.go
+++ b/destination_config.go
@@ -65,7 +65,7 @@ type DestinationConfigResponse struct {
 	ServerHostName       string `json:"server_host_name"`
 	HTTPPath             string `json:"http_path"`
 	PersonalAccessToken  string `json:"personal_access_token"`
-	CreateExternalTables bool   `json:"create_external_tables"`
+	CreateExternalTables *bool  `json:"create_external_tables"`
 	ExternalLocation     string `json:"external_location"`
 	AuthType             string `json:"auth_type"`
 	RoleArn              string `json:"role_arn"`

--- a/destination_config.go
+++ b/destination_config.go
@@ -55,7 +55,7 @@ type DestinationConfigResponse struct {
 	Auth                 string `json:"auth"`
 	User                 string `json:"user"`
 	Password             string `json:"password"`
-	ConnectionType       string `json:"connection_method"` // REST API returns "connection_method"
+	ConnectionMethod     string `json:"connection_method"` // REST API response of ConnectionType
 	TunnelHost           string `json:"tunnel_host"`
 	TunnelPort           string `json:"tunnel_port"`
 	TunnelUser           string `json:"tunnel_user"`


### PR DESCRIPTION
Changes in this PR: 

### Changed
- All `bool` fields of the types `DestinationConfigResponse`, `ConnectorConfigResponse`, `ConnectorCreateResponse`, `ConnectorDetailsResponse`, `ConnectorModifyResponse`, `ConnectorSetupTestsResponse`, and `ConnectorsSourceMetadataResponse` are now `*bool`.

### Removed
- Removed the unnecessary `ConnectorsSourceMetadataResponse.LinkToErd` JSON annotation `omitempty`.

### Fixed
- `DestinationConfigResponse` field `ConnectionType` has changed to `ConnectionMethod` to adequate the REST API response.
