### PR TITLE
pre-0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.1.0...HEAD)
 
 ### Changed
-- All `int` fields of the type `ConnectorConfigResponse` are not `*int`. 
+- All `int` fields of the type `ConnectorConfigResponse` are now `*int`. 
 - All `bool` fields of the types `DestinationConfigResponse`, `ConnectorConfigResponse`, `ConnectorCreateResponse`, `ConnectorDetailsResponse`, `ConnectorModifyResponse`, `ConnectorSetupTestsResponse`, and `ConnectorsSourceMetadataResponse` are now `*bool`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `UsersListResponse.Role`
-- `ConnectorConfig.AuthType` 
+- `GroupListUsersResponse.Role`
+- `ConnectorConfig.AuthType`
 - `ConnectorCreateService.SyncFrequency`
 - `ConnectorCreateService.DailySyncTime`
 - `ConnectorCreateService.PauseAfterTrial`
 - `ConnectorCreateResponse.Data.Paused`
-- `ConnectorCreateResponse.Data.PauseAfterTrial`
 - `ConnectorCreateResponse.Data.DailySyncTime`
+- `ConnectorCreateResponse.Data.PauseAfterTrial`
 - `ConnectorDetailsResponse.Data.Paused`
 - `ConnectorDetailsResponse.Data.PauseAfterTrial`
 - `ConnectorDetailsResponse.Data.DailySyncTime`
@@ -23,8 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - `ConnectorCreateService`, `ConnectorDetailsService`, `ConnectorModifyService`, and `ConnectorSetupTestsService` are now using REST API v2.
-- All `int` fields of the type `ConnectorConfigResponse` are now `*int`. 
-- All `bool` fields of the types `DestinationConfigResponse`, `ConnectorConfigResponse`, `ConnectorCreateResponse`, `ConnectorDetailsResponse`, `ConnectorModifyResponse`, `ConnectorSetupTestsResponse`, and `ConnectorsSourceMetadataResponse` are now `*bool`.
+- All `int` and `bool` fields of all response types are now `*int` and `*bool`. 
 
 ### Removed
 - Removed the unnecessary `ConnectorsSourceMetadataResponse.LinkToErd` JSON annotation `omitempty`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.1.0...HEAD)
 
 ### Changed
+- All `int` fields of the type `ConnectorConfigResponse` are not `*int`. 
 - All `bool` fields of the types `DestinationConfigResponse`, `ConnectorConfigResponse`, `ConnectorCreateResponse`, `ConnectorDetailsResponse`, `ConnectorModifyResponse`, `ConnectorSetupTestsResponse`, and `ConnectorsSourceMetadataResponse` are now `*bool`.
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.1.0...HEAD)
 
+### Added
+- `ConnectorConfig.AuthType` added. 
+
 ### Changed
+- `ConnectorCreateService`, `ConnectorDetailsService`, `ConnectorModifyService`, and `ConnectorSetupTestsService` are now using REST API v2.
 - All `int` fields of the type `ConnectorConfigResponse` are now `*int`. 
 - All `bool` fields of the types `DestinationConfigResponse`, `ConnectorConfigResponse`, `ConnectorCreateResponse`, `ConnectorDetailsResponse`, `ConnectorModifyResponse`, `ConnectorSetupTestsResponse`, and `ConnectorsSourceMetadataResponse` are now `*bool`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.1.0...HEAD)
 
 ### Added
-- `ConnectorConfig.AuthType` added. 
+- `UsersListResponse.Role`
+- `ConnectorConfig.AuthType` 
+- `ConnectorCreateService.SyncFrequency`
+- `ConnectorCreateService.DailySyncTime`
+- `ConnectorCreateService.PauseAfterTrial`
+- `ConnectorCreateResponse.Data.Paused`
+- `ConnectorCreateResponse.Data.PauseAfterTrial`
+- `ConnectorCreateResponse.Data.DailySyncTime`
+- `ConnectorDetailsResponse.Data.Paused`
+- `ConnectorDetailsResponse.Data.PauseAfterTrial`
+- `ConnectorDetailsResponse.Data.DailySyncTime`
+- `ConnectorModifyService.PauseAfterTrial` 
 
 ### Changed
 - `ConnectorCreateService`, `ConnectorDetailsService`, `ConnectorModifyService`, and `ConnectorSetupTestsService` are now using REST API v2.

--- a/README.md
+++ b/README.md
@@ -67,73 +67,73 @@ You can find examples for all services in the [examples](examples/) directory.
 
 ## API List
 
-The following [Fivetran REST API](https://fivetran.com/docs/rest-api) v1 endpoints are implemented by the Fivetran SDK for Go: 
+The following [Fivetran REST API](https://fivetran.com/docs/rest-api) endpoints are implemented by the Fivetran SDK for Go: 
 
 ### [User Management API](https://fivetran.com/docs/rest-api/users)
 
-REST API Endpoint | SDK Service
---- | ---
-[List all Users](https://fivetran.com/docs/rest-api/users#listallusers) | UsersListService
-[Retrieve user details](https://fivetran.com/docs/rest-api/users#retrieveuserdetails) | UserDetailsService
-[Invite a user](https://fivetran.com/docs/rest-api/users#inviteauser) | UserInviteService 
-[Modify a user](https://fivetran.com/docs/rest-api/users#modifyauser) | UserModifyService
-[Delete a user](https://fivetran.com/docs/rest-api/users#deleteauser) | UserDeleteService
+REST API Endpoint | REST API Version | SDK Service
+--- | --- | ---
+[List all Users](https://fivetran.com/docs/rest-api/users#listallusers) | v1 | [UsersListService](https://pkg.go.dev/github.com/fivetran/go-fivetran#UsersListService)
+[Retrieve user details](https://fivetran.com/docs/rest-api/users#retrieveuserdetails) | v1 | [UserDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#UserDetailsService)
+[Invite a user](https://fivetran.com/docs/rest-api/users#inviteauser) | v1 | [UserInviteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#UserInviteService) 
+[Modify a user](https://fivetran.com/docs/rest-api/users#modifyauser) | v1 | [UserModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#UserModifyService)
+[Delete a user](https://fivetran.com/docs/rest-api/users#deleteauser) | v1 | [UserDeleteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#UserDeleteService)
 
 ### [Group Management API](https://fivetran.com/docs/rest-api/groups)
 
-REST API Endpoint | SDK Service
---- | ---
-[Create a group](https://fivetran.com/docs/rest-api/groups#createagroup) | GroupCreateService
-[List all groups](https://fivetran.com/docs/rest-api/groups#listallgroups) | GroupsListService
-[Retrieve group details](https://fivetran.com/docs/rest-api/groups#retrievegroupdetails) | GroupDetailsService
-[Modify a group](https://fivetran.com/docs/rest-api/groups#modifyagroup) | GroupModifyService
-[List all connectors within a group](https://fivetran.com/docs/rest-api/groups#listallconnectorswithinagroup) | GroupListConnectorsService
-[List all users within a group](https://fivetran.com/docs/rest-api/groups#listalluserswithinagroup) | GroupListUsersService
-[Add a user to a group](https://fivetran.com/docs/rest-api/groups#addausertoagroup) | GroupAddUserService
-[Remove a user from a group](https://fivetran.com/docs/rest-api/groups#removeauserfromagroup) | GroupRemoveUserService
-[Delete a group](https://fivetran.com/docs/rest-api/groups#deleteagroup) | GroupDeleteService
+REST API Endpoint | REST API Version | SDK Service
+--- | --- | ---
+[Create a group](https://fivetran.com/docs/rest-api/groups#createagroup) | v1 | [GroupCreateService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupCreateService)
+[List all groups](https://fivetran.com/docs/rest-api/groups#listallgroups) | v1 | [GroupsListService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupsListService)
+[Retrieve group details](https://fivetran.com/docs/rest-api/groups#retrievegroupdetails) | v1 | [GroupDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupDetailsService)
+[Modify a group](https://fivetran.com/docs/rest-api/groups#modifyagroup) | v1 | [GroupModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupModifyService)
+[List all connectors within a group](https://fivetran.com/docs/rest-api/groups#listallconnectorswithinagroup) | v1 | [GroupListConnectorsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupListConnectorsService)
+[List all users within a group](https://fivetran.com/docs/rest-api/groups#listalluserswithinagroup) | v1 | [GroupListUsersService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupListUsersService)
+[Add a user to a group](https://fivetran.com/docs/rest-api/groups#addausertoagroup) | v1 | [GroupAddUserService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupAddUserService)
+[Remove a user from a group](https://fivetran.com/docs/rest-api/groups#removeauserfromagroup) | v1 | [GroupRemoveUserService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupRemoveUserService)
+[Delete a group](https://fivetran.com/docs/rest-api/groups#deleteagroup) | v1 | [GroupDeleteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#GroupDeleteService)
 
 ### [Destination Management API](https://fivetran.com/docs/rest-api/destinations)
 
-REST API Endpoint | SDK Service/Config
---- | ---
-[Create a destination](https://fivetran.com/docs/rest-api/destinations#createadestination) | DestinationCreateService
-[Retrieve destination details](https://fivetran.com/docs/rest-api/destinations#retrievedestinationdetails) | DestinationDetailsService
-[Modify a destination](https://fivetran.com/docs/rest-api/destinations#modifyadestination) | DestinationModifyService
-[Run destination setup tests](https://fivetran.com/docs/rest-api/destinations#rundestinationsetuptests) | DestinationSetupTestsService
-[Delete a destination](https://fivetran.com/docs/rest-api/destinations#deleteadestination) | DestinationDeleteService
-[Destination Config](https://fivetran.com/docs/rest-api/destinations/config) | DestinationConfig 
+REST API Endpoint | REST API Version | SDK Service/Config
+--- | --- | ---
+[Create a destination](https://fivetran.com/docs/rest-api/destinations#createadestination) | v1 | [DestinationCreateService](https://pkg.go.dev/github.com/fivetran/go-fivetran#DestinationCreateService)
+[Retrieve destination details](https://fivetran.com/docs/rest-api/destinations#retrievedestinationdetails) | v1 | [DestinationDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#DestinationDetailsService)
+[Modify a destination](https://fivetran.com/docs/rest-api/destinations#modifyadestination) | v1 | [DestinationModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#DestinationModifyService)
+[Run destination setup tests](https://fivetran.com/docs/rest-api/destinations#rundestinationsetuptests) | v1 | [DestinationSetupTestsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#DestinationSetupTestsService)
+[Delete a destination](https://fivetran.com/docs/rest-api/destinations#deleteadestination) | v1 | [DestinationDeleteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#DestinationDeleteService)
+[Destination Config](https://fivetran.com/docs/rest-api/destinations/config) | v1 | [DestinationConfig](https://pkg.go.dev/github.com/fivetran/go-fivetran#DestinationConfig)
 
 ### [Connector Management API](https://fivetran.com/docs/rest-api/connectors)
 
-REST API Endpoint | SDK Service/Config/Auth
---- | ---
-[Retrieve source metadata](https://fivetran.com/docs/rest-api/connectors#retrievesourcemetadata) | ConnectorsSourceMetadataService
-[Create a connector](https://fivetran.com/docs/rest-api/connectors#createaconnector) | ConnectorCreateService
-[Retrieve connector details](https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails) | ConnectorDetailsService
-[Modify a connector](https://fivetran.com/docs/rest-api/connectors#modifyaconnector) | ConnectorModifyService
-[Sync connector data](https://fivetran.com/docs/rest-api/connectors#syncconnectordata) | ConnectorSyncService
-[Re-sync connector table data](https://fivetran.com/docs/rest-api/connectors#resyncconnectortabledata) | ConnectorReSyncTableService
-[Run connector setup tests](https://fivetran.com/docs/rest-api/connectors#runconnectorsetuptests) | ConnectorSetupTestsService
-[Delete a connector](https://fivetran.com/docs/rest-api/connectors#deleteaconnector) | ConnectorDeleteService
-[Retrieve a connector schema config](https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig) | not implemented
-[Retrieve source table columns config](https://fivetran.com/docs/rest-api/connectors#retrievesourcetablecolumnsconfig) | not implemented
-[Reload a connector schema config](https://fivetran.com/docs/rest-api/connectors#reloadaconnectorschemaconfig) | not implemented
-[Modify a connector schema config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectorschemaconfig) | not implemented
-[Modify a connector database schema config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectordatabaseschemaconfig) | not implemented
-[Modify a connector table config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectortableconfig) | not implemented
-[Modify a connector column config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectorcolumnconfig) | not implemented
-[Connector Config](https://fivetran.com/docs/rest-api/connectors/config) | ConnectorConfig<br> ConnectorConfigReports<br> ConnectorConfigProjectCredentials<br> ConnectorConfigCustomTables
-[Connector Auth](https://fivetran.com/docs/rest-api/connectors) | ConnectorAuth<br> ConnectorAuthClientAccess
-[Connect Card](https://fivetran.com/docs/rest-api/connectors/connect-card) | not implemented
+REST API Endpoint | REST API Version | SDK Service/Config/Auth
+--- | --- | ---
+[Retrieve source metadata](https://fivetran.com/docs/rest-api/connectors#retrievesourcemetadata) | v1 | [ConnectorsSourceMetadataService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorsSourceMetadataService)
+[Create a connector](https://fivetran.com/docs/rest-api/connectors#createaconnector) | v1 | [ConnectorCreateService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorCreateService)
+[Retrieve connector details](https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails) | v1 | [ConnectorDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDetailsService)
+[Modify a connector](https://fivetran.com/docs/rest-api/connectors#modifyaconnector) | v1 | [ConnectorModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorModifyService)
+[Sync connector data](https://fivetran.com/docs/rest-api/connectors#syncconnectordata) | v1 | [ConnectorSyncService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSyncService)
+[Re-sync connector table data](https://fivetran.com/docs/rest-api/connectors#resyncconnectortabledata) | v1 | [ConnectorReSyncTableService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorReSyncTableService)
+[Run connector setup tests](https://fivetran.com/docs/rest-api/connectors#runconnectorsetuptests) | v1 | [ConnectorSetupTestsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSetupTestsService)
+[Delete a connector](https://fivetran.com/docs/rest-api/connectors#deleteaconnector) | v1 | [ConnectorDeleteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDeleteService)
+[Retrieve a connector schema config](https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig) | | not implemented
+[Retrieve source table columns config](https://fivetran.com/docs/rest-api/connectors#retrievesourcetablecolumnsconfig) | | not implemented
+[Reload a connector schema config](https://fivetran.com/docs/rest-api/connectors#reloadaconnectorschemaconfig) | | not implemented
+[Modify a connector schema config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectorschemaconfig) | | not implemented
+[Modify a connector database schema config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectordatabaseschemaconfig) | | not implemented
+[Modify a connector table config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectortableconfig) | | not implemented
+[Modify a connector column config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectorcolumnconfig) | | not implemented
+[Connector Config](https://fivetran.com/docs/rest-api/connectors/config) | v1 | [ConnectorConfig](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorConfig)<br> [ConnectorConfigReports](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorConfigReports)<br> [ConnectorConfigProjectCredentials](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorConfigProjectCredentials)<br> [ConnectorConfigCustomTables](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorConfigCustomTables)
+[Connector Auth](https://fivetran.com/docs/rest-api/connectors) | v1 | [ConnectorAuth](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorAuth)<br> [ConnectorAuthClientAccess](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorAuthClientAccess)
+[Connect Card](https://fivetran.com/docs/rest-api/connectors/connect-card) | | not implemented
 
 ### [Certificate Management API](https://fivetran.com/docs/rest-api/certificates)
-REST API Endpoint | SDK Service
---- | ---
-[Approve a connector certificate](https://fivetran.com/docs/rest-api/certificates#approveaconnectorcertificate) | CertificateConnectorCertificateApproveService
-[Approve a connector fingerprint](https://fivetran.com/docs/rest-api/certificates#approveaconnectorfingerprint) | CertificateConnectorFingerprintApproveService
-[Approve a destination certificate](https://fivetran.com/docs/rest-api/certificates#approveadestinationcertificate) | CertificateDestinationCertificateApproveService
-[Approve a destination fingerprint](https://fivetran.com/docs/rest-api/certificates#approveadestinationfingerprint) | CertificateDestinationFingerprintApproveService
+REST API Endpoint | REST API Version | SDK Service
+--- | --- | ---
+[Approve a connector certificate](https://fivetran.com/docs/rest-api/certificates#approveaconnectorcertificate) | v1 | [CertificateConnectorCertificateApproveService](https://pkg.go.dev/github.com/fivetran/go-fivetran#CertificateConnectorCertificateApproveService)
+[Approve a connector fingerprint](https://fivetran.com/docs/rest-api/certificates#approveaconnectorfingerprint) | v1 | [CertificateConnectorFingerprintApproveService](https://pkg.go.dev/github.com/fivetran/go-fivetran#CertificateConnectorFingerprintApproveService)
+[Approve a destination certificate](https://fivetran.com/docs/rest-api/certificates#approveadestinationcertificate) | v1 | [CertificateDestinationCertificateApproveService](https://pkg.go.dev/github.com/fivetran/go-fivetran#CertificateDestinationCertificateApproveService)
+[Approve a destination fingerprint](https://fivetran.com/docs/rest-api/certificates#approveadestinationfingerprint) | v1 | [CertificateDestinationFingerprintApproveService](https://pkg.go.dev/github.com/fivetran/go-fivetran#CertificateDestinationFingerprintApproveService)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ REST API Endpoint | REST API Version | SDK Service/Config/Auth
 [Retrieve connector details](https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails) | v2 | [ConnectorDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDetailsService)
 [Modify a connector](https://fivetran.com/docs/rest-api/connectors#modifyaconnector) | v2 | [ConnectorModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorModifyService)
 [Sync connector data](https://fivetran.com/docs/rest-api/connectors#syncconnectordata) | v1 | [ConnectorSyncService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSyncService)
-[Re-sync connector table data](https://fivetran.com/docs/rest-api/connectors#resyncconnectortabledata) | v2 | [ConnectorReSyncTableService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorReSyncTableService)
-[Run connector setup tests](https://fivetran.com/docs/rest-api/connectors#runconnectorsetuptests) | v1 | [ConnectorSetupTestsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSetupTestsService)
+[Re-sync connector table data](https://fivetran.com/docs/rest-api/connectors#resyncconnectortabledata) | v1 | [ConnectorReSyncTableService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorReSyncTableService)
+[Run connector setup tests](https://fivetran.com/docs/rest-api/connectors#runconnectorsetuptests) | v2 | [ConnectorSetupTestsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSetupTestsService)
 [Delete a connector](https://fivetran.com/docs/rest-api/connectors#deleteaconnector) | v1 | [ConnectorDeleteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDeleteService)
 [Retrieve a connector schema config](https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig) | | not implemented
 [Retrieve source table columns config](https://fivetran.com/docs/rest-api/connectors#retrievesourcetablecolumnsconfig) | | not implemented

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Checkout our [CHANGELOG](CHANGELOG.md) for information about the latest bug fixe
 
 Make sure you read the Fivetran REST API [documentation](https://fivetran.com/docs/rest-api) before using the SDK.
 
+**NOTE**: `go-fivetran` is still in [ALPHA](https://en.wikipedia.org/wiki/Software_release_life_cycle#Alpha) development stage. Future versions may introduce breaking changes. 
+
 ## Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ REST API Endpoint | REST API Version | SDK Service/Config
 REST API Endpoint | REST API Version | SDK Service/Config/Auth
 --- | --- | ---
 [Retrieve source metadata](https://fivetran.com/docs/rest-api/connectors#retrievesourcemetadata) | v1 | [ConnectorsSourceMetadataService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorsSourceMetadataService)
-[Create a connector](https://fivetran.com/docs/rest-api/connectors#createaconnector) | v1 | [ConnectorCreateService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorCreateService)
-[Retrieve connector details](https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails) | v1 | [ConnectorDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDetailsService)
-[Modify a connector](https://fivetran.com/docs/rest-api/connectors#modifyaconnector) | v1 | [ConnectorModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorModifyService)
+[Create a connector](https://fivetran.com/docs/rest-api/connectors#createaconnector) | v2 | [ConnectorCreateService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorCreateService)
+[Retrieve connector details](https://fivetran.com/docs/rest-api/connectors#retrieveconnectordetails) | v2 | [ConnectorDetailsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDetailsService)
+[Modify a connector](https://fivetran.com/docs/rest-api/connectors#modifyaconnector) | v2 | [ConnectorModifyService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorModifyService)
 [Sync connector data](https://fivetran.com/docs/rest-api/connectors#syncconnectordata) | v1 | [ConnectorSyncService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSyncService)
-[Re-sync connector table data](https://fivetran.com/docs/rest-api/connectors#resyncconnectortabledata) | v1 | [ConnectorReSyncTableService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorReSyncTableService)
+[Re-sync connector table data](https://fivetran.com/docs/rest-api/connectors#resyncconnectortabledata) | v2 | [ConnectorReSyncTableService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorReSyncTableService)
 [Run connector setup tests](https://fivetran.com/docs/rest-api/connectors#runconnectorsetuptests) | v1 | [ConnectorSetupTestsService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorSetupTestsService)
 [Delete a connector](https://fivetran.com/docs/rest-api/connectors#deleteaconnector) | v1 | [ConnectorDeleteService](https://pkg.go.dev/github.com/fivetran/go-fivetran#ConnectorDeleteService)
 [Retrieve a connector schema config](https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig) | | not implemented

--- a/connector_config.go
+++ b/connector_config.go
@@ -189,6 +189,7 @@ type ConnectorConfig struct {
 	userName                         *string
 	reportURL                        *string
 	uniqueID                         *string
+	authType                         *string
 }
 
 type connectorConfigRequest struct {
@@ -378,6 +379,7 @@ type connectorConfigRequest struct {
 	UserName                         *string                                     `json:"user_name,omitempty"`
 	ReportURL                        *string                                     `json:"report_url,omitempty"`
 	UniqueID                         *string                                     `json:"unique_id,omitempty"`
+	AuthType                         *string                                     `json:"auth_type,omitempty"`
 }
 
 type ConnectorConfigResponse struct {
@@ -567,6 +569,7 @@ type ConnectorConfigResponse struct {
 	UserName                         string                                      `json:"user_name"`
 	ReportURL                        string                                      `json:"report_url"`
 	UniqueID                         string                                      `json:"unique_id"`
+	AuthType                         string                                      `json:"auth_type"`
 	LatestVersion                    string                                      `json:"latest_version"`
 	AuthorizationMethod              string                                      `json:"authorization_method"`
 	ServiceVersion                   string                                      `json:"service_version"`
@@ -786,6 +789,7 @@ func (cc *ConnectorConfig) request() *connectorConfigRequest {
 		UserName:                         cc.userName,
 		ReportURL:                        cc.reportURL,
 		UniqueID:                         cc.uniqueID,
+		AuthType:                         cc.authType,
 	}
 }
 
@@ -1716,5 +1720,10 @@ func (cc *ConnectorConfig) ReportURL(value string) *ConnectorConfig {
 
 func (cc *ConnectorConfig) UniqueID(value string) *ConnectorConfig {
 	cc.uniqueID = &value
+	return cc
+}
+
+func (cc *ConnectorConfig) AuthType(value string) *ConnectorConfig {
+	cc.authType = &value
 	return cc
 }

--- a/connector_config.go
+++ b/connector_config.go
@@ -402,12 +402,12 @@ type ConnectorConfigResponse struct {
 	ABSConnectionString              string                                      `json:"abs_connection_string"`
 	ABSContainerName                 string                                      `json:"abs_container_name"`
 	FTPHost                          string                                      `json:"ftp_host"`
-	FTPPort                          int                                         `json:"ftp_port"`
+	FTPPort                          *int                                        `json:"ftp_port"`
 	FTPUser                          string                                      `json:"ftp_user"`
 	FTPPassword                      string                                      `json:"ftp_password"`
 	IsFTPS                           *bool                                       `json:"is_ftps"`
 	SFTPHost                         string                                      `json:"sftp_host"`
-	SFTPPort                         int                                         `json:"sftp_port"`
+	SFTPPort                         *int                                        `json:"sftp_port"`
 	SFTPUser                         string                                      `json:"sftp_user"`
 	SFTPPassword                     string                                      `json:"sftp_password"`
 	SFTPIsKeyPair                    *bool                                       `json:"sftp_is_key_pair"`
@@ -500,7 +500,7 @@ type ConnectorConfigResponse struct {
 	CustomerID                       string                                      `json:"customer_id"`
 	ManagerAccounts                  []string                                    `json:"manager_accounts"`
 	Reports                          []ConnectorConfigReportsResponse            `json:"reports"`
-	ConversionWindowSize             int                                         `json:"conversion_window_size"`
+	ConversionWindowSize             *int                                        `json:"conversion_window_size"`
 	Profiles                         []string                                    `json:"profiles"`
 	ProjectID                        string                                      `json:"project_id"`
 	DatasetID                        string                                      `json:"dataset_id"`
@@ -519,13 +519,13 @@ type ConnectorConfigResponse struct {
 	APIKeys                          string                                      `json:"api_keys"`
 	Endpoint                         string                                      `json:"endpoint"`
 	Identity                         string                                      `json:"identity"`
-	APIQuota                         int                                         `json:"api_quota"`
+	APIQuota                         *int                                        `json:"api_quota"`
 	DomainName                       string                                      `json:"domain_name"`
 	ResourceURL                      string                                      `json:"resource_url"`
 	APISecret                        string                                      `json:"api_secret"`
 	Hosts                            []string                                    `json:"hosts"`
 	TunnelHost                       string                                      `json:"tunnel_host"`
-	TunnelPort                       int                                         `json:"tunnel_port"`
+	TunnelPort                       *int                                        `json:"tunnel_port"`
 	TunnelUser                       string                                      `json:"tunnel_user"`
 	Database                         string                                      `json:"database"`
 	Datasource                       string                                      `json:"datasource"`
@@ -536,7 +536,7 @@ type ConnectorConfigResponse struct {
 	ServerURL                        string                                      `json:"server_url"`
 	UserKey                          string                                      `json:"user_key"`
 	APIVersion                       string                                      `json:"api_version"`
-	DailyAPICallLimit                int                                         `json:"daily_api_call_limit"`
+	DailyAPICallLimit                *int                                        `json:"daily_api_call_limit"`
 	TimeZone                         string                                      `json:"time_zone"`
 	IntegrationKey                   string                                      `json:"integration_key"`
 	Advertisers                      []string                                    `json:"advertisers"`

--- a/connector_create.go
+++ b/connector_create.go
@@ -45,16 +45,16 @@ type ConnectorCreateResponse struct {
 		ID              string    `json:"id"`
 		GroupID         string    `json:"group_id"`
 		Service         string    `json:"service"`
-		ServiceVersion  int       `json:"service_version"`
+		ServiceVersion  *int      `json:"service_version"`
 		Schema          string    `json:"schema"`
 		ConnectedBy     string    `json:"connected_by"`
 		CreatedAt       time.Time `json:"created_at"`
 		SucceededAt     time.Time `json:"succeeded_at"`
 		FailedAt        time.Time `json:"failed_at"`
-		SyncFrequency   int       `json:"sync_frequency"`
+		SyncFrequency   *int      `json:"sync_frequency"`
 		ScheduleType    string    `json:"schedule_type"`
-		Paused          bool      `json:"paused"`
-		PauseAfterTrial bool      `json:"pause_after_trial"`
+		Paused          *bool     `json:"paused"`
+		PauseAfterTrial *bool     `json:"pause_after_trial"`
 		DailySyncTime   string    `json:"daily_sync_time"`
 		Status          struct {
 			SetupState       string `json:"setup_state"`
@@ -103,6 +103,9 @@ func (s *ConnectorCreateService) request() *connectorCreateRequest {
 		Paused:            s.paused,
 		Config:            config,
 		Auth:              auth,
+		SyncFrequency:     s.syncFrequency,
+		DailySyncTime:     s.dailySyncTime,
+		PauseAfterTrial:   s.pauseAfterTrial,
 	}
 }
 

--- a/connector_create.go
+++ b/connector_create.go
@@ -68,6 +68,7 @@ type ConnectorCreateResponse struct {
 		} `json:"setup_tests"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
+	// SourceSyncDetails // TODO
 }
 
 func (c *Client) NewConnectorCreate() *ConnectorCreateService {

--- a/connector_create.go
+++ b/connector_create.go
@@ -68,7 +68,6 @@ type ConnectorCreateResponse struct {
 		} `json:"setup_tests"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
-	// SourceSyncDetails // TODO
 }
 
 func (c *Client) NewConnectorCreate() *ConnectorCreateService {

--- a/connector_create.go
+++ b/connector_create.go
@@ -145,6 +145,7 @@ func (s *ConnectorCreateService) Do(ctx context.Context) (ConnectorCreateRespons
 	headers := make(map[string]string)
 	headers["Authorization"] = s.c.authorization
 	headers["Content-Type"] = "application/json"
+	headers["Accept"] = "application/json;version=2"
 
 	reqBody, err := json.Marshal(s.request())
 	if err != nil {

--- a/connector_create.go
+++ b/connector_create.go
@@ -17,6 +17,9 @@ type ConnectorCreateService struct {
 	trustFingerprints *bool
 	runSetupTests     *bool
 	paused            *bool
+	syncFrequency     *int
+	dailySyncTime     *string
+	pauseAfterTrial   *bool
 	config            *ConnectorConfig
 	auth              *ConnectorAuth
 }
@@ -28,6 +31,9 @@ type connectorCreateRequest struct {
 	TrustFingerprints *bool                   `json:"trust_fingerprints,omitempty"`
 	RunSetupTests     *bool                   `json:"run_setup_tests,omitempty"`
 	Paused            *bool                   `json:"paused,omitempty"`
+	SyncFrequency     *int                    `json:"sync_frequency,omitempty"`    // new TODO: ADD METHOD
+	DailySyncTime     *string                 `json:"daily_sync_time,omitempty"`   // new TODO: ADD METHOD
+	PauseAfterTrial   *bool                   `json:"pause_after_trial,omitempty"` // new TODO: ADD METHOD
 	Config            *connectorConfigRequest `json:"config,omitempty"`
 	Auth              *connectorAuthRequest   `json:"auth,omitempty"`
 }
@@ -36,18 +42,21 @@ type ConnectorCreateResponse struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 	Data    struct {
-		ID             string    `json:"id"`
-		GroupID        string    `json:"group_id"`
-		Service        string    `json:"service"`
-		ServiceVersion int       `json:"service_version"`
-		Schema         string    `json:"schema"`
-		ConnectedBy    string    `json:"connected_by"`
-		CreatedAt      time.Time `json:"created_at"`
-		SucceededAt    time.Time `json:"succeeded_at"`
-		FailedAt       time.Time `json:"failed_at"`
-		SyncFrequency  int       `json:"sync_frequency"`
-		ScheduleType   string    `json:"schedule_type"`
-		Status         struct {
+		ID              string    `json:"id"`
+		GroupID         string    `json:"group_id"`
+		Service         string    `json:"service"`
+		ServiceVersion  int       `json:"service_version"`
+		Schema          string    `json:"schema"`
+		ConnectedBy     string    `json:"connected_by"`
+		CreatedAt       time.Time `json:"created_at"`
+		SucceededAt     time.Time `json:"succeeded_at"`
+		FailedAt        time.Time `json:"failed_at"`
+		SyncFrequency   int       `json:"sync_frequency"`
+		ScheduleType    string    `json:"schedule_type"`
+		Paused          bool      `json:"paused"`
+		PauseAfterTrial bool      `json:"pause_after_trial"`
+		DailySyncTime   string    `json:"daily_sync_time"`
+		Status          struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`
@@ -124,6 +133,21 @@ func (s *ConnectorCreateService) RunSetupTests(value bool) *ConnectorCreateServi
 
 func (s *ConnectorCreateService) Paused(value bool) *ConnectorCreateService {
 	s.paused = &value
+	return s
+}
+
+func (s *ConnectorCreateService) SyncFrequency(value int) *ConnectorCreateService {
+	s.syncFrequency = &value
+	return s
+}
+
+func (s *ConnectorCreateService) DailySyncTime(value string) *ConnectorCreateService {
+	s.dailySyncTime = &value
+	return s
+}
+
+func (s *ConnectorCreateService) PauseAfterTrial(value bool) *ConnectorCreateService {
+	s.pauseAfterTrial = &value
 	return s
 }
 

--- a/connector_create.go
+++ b/connector_create.go
@@ -31,9 +31,9 @@ type connectorCreateRequest struct {
 	TrustFingerprints *bool                   `json:"trust_fingerprints,omitempty"`
 	RunSetupTests     *bool                   `json:"run_setup_tests,omitempty"`
 	Paused            *bool                   `json:"paused,omitempty"`
-	SyncFrequency     *int                    `json:"sync_frequency,omitempty"`    // new TODO: ADD METHOD
-	DailySyncTime     *string                 `json:"daily_sync_time,omitempty"`   // new TODO: ADD METHOD
-	PauseAfterTrial   *bool                   `json:"pause_after_trial,omitempty"` // new TODO: ADD METHOD
+	SyncFrequency     *int                    `json:"sync_frequency,omitempty"`
+	DailySyncTime     *string                 `json:"daily_sync_time,omitempty"`
+	PauseAfterTrial   *bool                   `json:"pause_after_trial,omitempty"`
 	Config            *connectorConfigRequest `json:"config,omitempty"`
 	Auth              *connectorAuthRequest   `json:"auth,omitempty"`
 }

--- a/connector_details.go
+++ b/connector_details.go
@@ -48,7 +48,7 @@ type ConnectorDetailsResponse struct {
 		} `json:"status"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
-	// SourceSyncDetails not implemented yet. https://fivetran.height.app/T-114130
+	// SourceSyncDetails not implemented yet. T-114130
 }
 
 func (c *Client) NewConnectorDetails() *ConnectorDetailsService {

--- a/connector_details.go
+++ b/connector_details.go
@@ -45,7 +45,7 @@ type ConnectorDetailsResponse struct {
 		} `json:"status"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
-	// SourceSyncDetails // TODO
+	// SourceSyncDetails not implemented yet. https://fivetran.height.app/T-114130
 }
 
 func (c *Client) NewConnectorDetails() *ConnectorDetailsService {

--- a/connector_details.go
+++ b/connector_details.go
@@ -18,18 +18,21 @@ type ConnectorDetailsResponse struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 	Data    struct {
-		ID             string    `json:"id"`
-		GroupID        string    `json:"group_id"`
-		Service        string    `json:"service"`
-		ServiceVersion int       `json:"service_version"`
-		Schema         string    `json:"schema"`
-		ConnectedBy    string    `json:"connected_by"`
-		CreatedAt      time.Time `json:"created_at"`
-		SucceededAt    time.Time `json:"succeeded_at"`
-		FailedAt       time.Time `json:"failed_at"`
-		SyncFrequency  int       `json:"sync_frequency"`
-		ScheduleType   string    `json:"schedule_type"`
-		Status         struct {
+		ID              string    `json:"id"`
+		GroupID         string    `json:"group_id"`
+		Service         string    `json:"service"`
+		ServiceVersion  int       `json:"service_version"`
+		Schema          string    `json:"schema"`
+		ConnectedBy     string    `json:"connected_by"`
+		CreatedAt       time.Time `json:"created_at"`
+		SucceededAt     time.Time `json:"succeeded_at"`
+		FailedAt        time.Time `json:"failed_at"`
+		Paused          bool      `json:"paused"`            // POINTER ???
+		PauseAfterTrial bool      `json:"pause_after_trial"` // POINTER ???
+		DailySyncTime   string    `json:"daily_sync_time"`
+		SyncFrequency   int       `json:"sync_frequency"`
+		ScheduleType    string    `json:"schedule_type"`
+		Status          struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`

--- a/connector_details.go
+++ b/connector_details.go
@@ -21,16 +21,16 @@ type ConnectorDetailsResponse struct {
 		ID              string    `json:"id"`
 		GroupID         string    `json:"group_id"`
 		Service         string    `json:"service"`
-		ServiceVersion  int       `json:"service_version"`
+		ServiceVersion  *int      `json:"service_version"`
 		Schema          string    `json:"schema"`
 		ConnectedBy     string    `json:"connected_by"`
 		CreatedAt       time.Time `json:"created_at"`
 		SucceededAt     time.Time `json:"succeeded_at"`
 		FailedAt        time.Time `json:"failed_at"`
-		Paused          bool      `json:"paused"`            // POINTER ???
-		PauseAfterTrial bool      `json:"pause_after_trial"` // POINTER ???
+		Paused          *bool     `json:"paused"`
+		PauseAfterTrial *bool     `json:"pause_after_trial"`
 		DailySyncTime   string    `json:"daily_sync_time"`
-		SyncFrequency   int       `json:"sync_frequency"`
+		SyncFrequency   *int      `json:"sync_frequency"`
 		ScheduleType    string    `json:"schedule_type"`
 		Status          struct {
 			SetupState       string `json:"setup_state"`

--- a/connector_details.go
+++ b/connector_details.go
@@ -68,6 +68,7 @@ func (s *ConnectorDetailsService) Do(ctx context.Context) (ConnectorDetailsRespo
 
 	headers := make(map[string]string)
 	headers["Authorization"] = s.c.authorization
+	headers["Accept"] = "application/json;version=2"
 
 	r := request{
 		method:  "GET",

--- a/connector_details.go
+++ b/connector_details.go
@@ -45,6 +45,7 @@ type ConnectorDetailsResponse struct {
 		} `json:"status"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
+	// SourceSyncDetails // TODO
 }
 
 func (c *Client) NewConnectorDetails() *ConnectorDetailsService {

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -73,7 +73,6 @@ type ConnectorModifyResponse struct {
 		} `json:"setup_tests"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
-	// SourceSyncDetails // TODO
 }
 
 func (c *Client) NewConnectorModify() *ConnectorModifyService {

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -172,6 +172,7 @@ func (s *ConnectorModifyService) Do(ctx context.Context) (ConnectorModifyRespons
 	headers := make(map[string]string)
 	headers["Authorization"] = s.c.authorization
 	headers["Content-Type"] = "application/json"
+	headers["Accept"] = "application/json;version=2"
 
 	reqBody, err := json.Marshal(s.request())
 	if err != nil {

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -43,18 +43,20 @@ type ConnectorModifyResponse struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 	Data    struct {
-		ID             string    `json:"id"`
-		GroupID        string    `json:"group_id"`
-		Service        string    `json:"service"`
-		ServiceVersion int       `json:"service_version"`
-		Schema         string    `json:"schema"`
-		ConnectedBy    string    `json:"connected_by"`
-		CreatedAt      time.Time `json:"created_at"`
-		SucceededAt    time.Time `json:"succeeded_at"`
-		FailedAt       time.Time `json:"failed_at"`
-		SyncFrequency  int       `json:"sync_frequency"`
-		ScheduleType   string    `json:"schedule_type"`
-		Status         struct {
+		ID              string    `json:"id"`
+		GroupID         string    `json:"group_id"`
+		Service         string    `json:"service"`
+		ServiceVersion  *int      `json:"service_version"`
+		Schema          string    `json:"schema"`
+		ConnectedBy     string    `json:"connected_by"`
+		CreatedAt       time.Time `json:"created_at"`
+		SucceededAt     time.Time `json:"succeeded_at"`
+		FailedAt        time.Time `json:"failed_at"`
+		SyncFrequency   *int      `json:"sync_frequency"`
+		Paused          *bool     `json:"paused"`
+		PauseAfterTrial *bool     `json:"pause_after_trial"`
+		ScheduleType    string    `json:"schedule_type"`
+		Status          struct {
 			SetupState       string `json:"setup_state"`
 			SyncState        string `json:"sync_state"`
 			UpdateState      string `json:"update_state"`
@@ -103,6 +105,7 @@ func (s *ConnectorModifyService) request() *connectorModifyRequest {
 		IsHistoricalSync:  s.isHistoricalSync,
 		ScheduleType:      s.scheduleType,
 		RunSetupTests:     s.runSetupTests,
+		PauseAfterTrial:   s.pauseAfterTrial,
 	}
 }
 

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -73,6 +73,7 @@ type ConnectorModifyResponse struct {
 		} `json:"setup_tests"`
 		Config ConnectorConfigResponse `json:"config"`
 	} `json:"data"`
+	// SourceSyncDetails // TODO
 }
 
 func (c *Client) NewConnectorModify() *ConnectorModifyService {

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -22,6 +22,7 @@ type ConnectorModifyService struct {
 	isHistoricalSync  *bool
 	scheduleType      *string
 	runSetupTests     *bool
+	pauseAfterTrial   *bool
 }
 
 type connectorModifyRequest struct {
@@ -35,6 +36,7 @@ type connectorModifyRequest struct {
 	IsHistoricalSync  *bool                   `json:"is_historical_sync,omitempty"`
 	ScheduleType      *string                 `json:"schedule_type,omitempty"`
 	RunSetupTests     *bool                   `json:"run_setup_tests,omitempty"`
+	PauseAfterTrial   *bool                   `json:"pause_after_trial,omitempty"`
 }
 
 type ConnectorModifyResponse struct {
@@ -156,6 +158,11 @@ func (s *ConnectorModifyService) ScheduleType(value string) *ConnectorModifyServ
 
 func (s *ConnectorModifyService) RunSetupTests(value bool) *ConnectorModifyService {
 	s.runSetupTests = &value
+	return s
+}
+
+func (s *ConnectorModifyService) PauseAfterTrial(value bool) *ConnectorModifyService {
+	s.pauseAfterTrial = &value
 	return s
 }
 

--- a/connector_resync_table.go
+++ b/connector_resync_table.go
@@ -57,7 +57,6 @@ func (s *ConnectorReSyncTableService) Do(ctx context.Context) (ConnectorReSyncTa
 
 	headers := make(map[string]string)
 	headers["Authorization"] = s.c.authorization
-	headers["Accept"] = "application/json;version=2"
 
 	r := request{
 		method:  "POST",

--- a/connector_resync_table.go
+++ b/connector_resync_table.go
@@ -57,6 +57,7 @@ func (s *ConnectorReSyncTableService) Do(ctx context.Context) (ConnectorReSyncTa
 
 	headers := make(map[string]string)
 	headers["Authorization"] = s.c.authorization
+	headers["Accept"] = "application/json;version=2"
 
 	r := request{
 		method:  "POST",

--- a/connector_setup_tests.go
+++ b/connector_setup_tests.go
@@ -28,13 +28,13 @@ type ConnectorSetupTestsResponse struct {
 		ID             string    `json:"id"`
 		GroupID        string    `json:"group_id"`
 		Service        string    `json:"service"`
-		ServiceVersion int       `json:"service_version"`
+		ServiceVersion *int      `json:"service_version"`
 		Schema         string    `json:"schema"`
 		ConnectedBy    string    `json:"connected_by"`
 		CreatedAt      time.Time `json:"created_at"`
 		SucceededAt    time.Time `json:"succeeded_at"`
 		FailedAt       time.Time `json:"failed_at"`
-		SyncFrequency  int       `json:"sync_frequency"`
+		SyncFrequency  *int      `json:"sync_frequency"`
 		ScheduleType   string    `json:"schedule_type"`
 		Status         struct {
 			SetupState       string `json:"setup_state"`

--- a/connector_setup_tests.go
+++ b/connector_setup_tests.go
@@ -98,6 +98,7 @@ func (s *ConnectorSetupTestsService) Do(ctx context.Context) (ConnectorSetupTest
 	headers := make(map[string]string)
 	headers["Authorization"] = s.c.authorization
 	headers["Content-Type"] = "application/json"
+	headers["Accept"] = "application/json;version=2"
 
 	reqBody, err := json.Marshal(s.request())
 	if err != nil {

--- a/destination_config.go
+++ b/destination_config.go
@@ -50,7 +50,7 @@ type destinationConfigRequest struct {
 
 type DestinationConfigResponse struct {
 	Host                 string `json:"host"`
-	Port                 string `json:"port"`
+	Port                 string `json:"port"` // Request `int`, Response `string`
 	Database             string `json:"database"`
 	Auth                 string `json:"auth"`
 	User                 string `json:"user"`

--- a/group_list_connectors.go
+++ b/group_list_connectors.go
@@ -25,19 +25,19 @@ type GroupListConnectorsResponse struct {
 			ID             string    `json:"id"`
 			GroupID        string    `json:"group_id"`
 			Service        string    `json:"service"`
-			ServiceVersion int       `json:"service_version"`
+			ServiceVersion *int      `json:"service_version"`
 			Schema         string    `json:"schema"`
 			ConnectedBy    string    `json:"connected_by"`
 			CreatedAt      time.Time `json:"created_at"`
 			SucceededAt    time.Time `json:"succeeded_at"`
 			FailedAt       time.Time `json:"failed_at"`
-			SyncFrequency  int       `json:"sync_frequency"`
+			SyncFrequency  *int      `json:"sync_frequency"`
 			ScheduleType   string    `json:"schedule_type"`
 			Status         struct {
 				SetupState       string `json:"setup_state"`
 				SyncState        string `json:"sync_state"`
 				UpdateState      string `json:"update_state"`
-				IsHistoricalSync bool   `json:"is_historical_sync"`
+				IsHistoricalSync *bool  `json:"is_historical_sync"`
 				Tasks            []struct {
 					Code    string `json:"code"`
 					Message string `json:"message"`

--- a/group_list_users.go
+++ b/group_list_users.go
@@ -25,10 +25,11 @@ type GroupListUsersResponse struct {
 			Email      string    `json:"email"`
 			GivenName  string    `json:"given_name"`
 			FamilyName string    `json:"family_name"`
-			Verified   bool      `json:"verified"`
-			Invited    bool      `json:"invited"`
+			Verified   *bool     `json:"verified"`
+			Invited    *bool     `json:"invited"`
 			Picture    string    `json:"picture"`
 			Phone      string    `json:"phone"`
+			Role       string    `json:"role"`
 			LoggedInAt time.Time `json:"logged_in_at"`
 			CreatedAt  time.Time `json:"created_at"`
 		} `json:"items"`

--- a/user_details.go
+++ b/user_details.go
@@ -22,8 +22,8 @@ type UserDetailsResponse struct {
 		Email      string    `json:"email"`
 		GivenName  string    `json:"given_name"`
 		FamilyName string    `json:"family_name"`
-		Verified   bool      `json:"verified"`
-		Invited    bool      `json:"invited"`
+		Verified   *bool     `json:"verified"`
+		Invited    *bool     `json:"invited"`
 		Picture    string    `json:"picture"`
 		Phone      string    `json:"phone"`
 		LoggedInAt time.Time `json:"logged_in_at"`

--- a/user_invite.go
+++ b/user_invite.go
@@ -36,8 +36,8 @@ type UserInviteResponse struct {
 		Email      string    `json:"email"`
 		GivenName  string    `json:"given_name"`
 		FamilyName string    `json:"family_name"`
-		Verified   bool      `json:"verified"`
-		Invited    bool      `json:"invited"`
+		Verified   *bool     `json:"verified"`
+		Invited    *bool     `json:"invited"`
 		Picture    string    `json:"picture"`
 		Phone      string    `json:"phone"`
 		LoggedInAt time.Time `json:"logged_in_at"`

--- a/user_modify.go
+++ b/user_modify.go
@@ -35,8 +35,8 @@ type UserModifyResponse struct {
 		Email      string    `json:"email"`
 		GivenName  string    `json:"given_name"`
 		FamilyName string    `json:"family_name"`
-		Verified   bool      `json:"verified"`
-		Invited    bool      `json:"invited"`
+		Verified   *bool     `json:"verified"`
+		Invited    *bool     `json:"invited"`
 		Picture    string    `json:"picture"`
 		Phone      string    `json:"phone"`
 		LoggedInAt time.Time `json:"logged_in_at"`

--- a/users_list.go
+++ b/users_list.go
@@ -24,8 +24,8 @@ type UsersListResponse struct {
 			Email      string    `json:"email"`
 			GivenName  string    `json:"given_name"`
 			FamilyName string    `json:"family_name"`
-			Verified   bool      `json:"verified"`
-			Invited    bool      `json:"invited"`
+			Verified   *bool     `json:"verified"`
+			Invited    *bool     `json:"invited"`
 			Picture    string    `json:"picture"`
 			Phone      string    `json:"phone"`
 			Role       string    `json:"role"`

--- a/users_list.go
+++ b/users_list.go
@@ -28,6 +28,7 @@ type UsersListResponse struct {
 			Invited    bool      `json:"invited"`
 			Picture    string    `json:"picture"`
 			Phone      string    `json:"phone"`
+			Role       string    `json:"role"`
 			LoggedInAt time.Time `json:"logged_in_at"`
 			CreatedAt  time.Time `json:"created_at"`
 		} `json:"items"`


### PR DESCRIPTION
This PR: 
- Implements REST API changes released in June and July 2021.
- Some connectors services are now using REST API v2.
- ints and bools fields of all response types are now using pointers. 
See the CHANGELOG for details. 