### PR TITLE
fix(go-fivetran): add secret_key fields to Destination request/response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.2.1...HEAD)
 
+## [0.2.2](https://github.com/fivetran/go-fivetran/compare/v0.2.1...v0.2.2) - 2021-09-22
+
+## Fixed
+
+- `DestinationConfigRequest.SecretKey` missing field secret_key added
+
 ## [0.2.1](https://github.com/fivetran/go-fivetran/compare/v0.2.0...v0.2.1) - 2021-07-27
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.2](https://github.com/fivetran/go-fivetran/compare/v0.2.1...v0.2.2) - 2021-09-22
 
 ## Fixed
-
-- `DestinationConfigRequest.SecretKey` missing field secret_key added
+- `DestinationConfigRequest.SecretKey` missing field added.
 
 ## [0.2.1](https://github.com/fivetran/go-fivetran/compare/v0.2.0...v0.2.1) - 2021-07-27
 

--- a/destination_config.go
+++ b/destination_config.go
@@ -23,7 +23,7 @@ type DestinationConfig struct {
 	externalLocation     *string
 	authType             *string
 	roleArn              *string
-	secretKey			 *string
+	secretKey            *string
 }
 
 type destinationConfigRequest struct {
@@ -47,7 +47,7 @@ type destinationConfigRequest struct {
 	ExternalLocation     *string `json:"external_location,omitempty"`
 	AuthType             *string `json:"auth_type,omitempty"`
 	RoleArn              *string `json:"role_arn,omitempty"`
-	SecretKey			 *string `json:"secret_key,omitempty"`
+	SecretKey            *string `json:"secret_key,omitempty"`
 }
 
 type DestinationConfigResponse struct {
@@ -71,7 +71,7 @@ type DestinationConfigResponse struct {
 	ExternalLocation     string `json:"external_location"`
 	AuthType             string `json:"auth_type"`
 	RoleArn              string `json:"role_arn"`
-	SecretKey			 string `json:"secret_key"`
+	SecretKey            string `json:"secret_key"`
 }
 
 func NewDestinationConfig() *DestinationConfig {
@@ -100,7 +100,7 @@ func (dc *DestinationConfig) request() *destinationConfigRequest {
 		ExternalLocation:     dc.externalLocation,
 		AuthType:             dc.authType,
 		RoleArn:              dc.roleArn,
-		SecretKey:			  dc.secretKey,
+		SecretKey:            dc.secretKey,
 	}
 }
 

--- a/destination_config.go
+++ b/destination_config.go
@@ -23,6 +23,7 @@ type DestinationConfig struct {
 	externalLocation     *string
 	authType             *string
 	roleArn              *string
+	secretKey			 *string
 }
 
 type destinationConfigRequest struct {
@@ -46,6 +47,7 @@ type destinationConfigRequest struct {
 	ExternalLocation     *string `json:"external_location,omitempty"`
 	AuthType             *string `json:"auth_type,omitempty"`
 	RoleArn              *string `json:"role_arn,omitempty"`
+	SecretKey			 *string `json:"secret_key,omitempty"`
 }
 
 type DestinationConfigResponse struct {
@@ -69,6 +71,7 @@ type DestinationConfigResponse struct {
 	ExternalLocation     string `json:"external_location"`
 	AuthType             string `json:"auth_type"`
 	RoleArn              string `json:"role_arn"`
+	SecretKey			 string `json:"secret_key"`
 }
 
 func NewDestinationConfig() *DestinationConfig {
@@ -97,6 +100,7 @@ func (dc *DestinationConfig) request() *destinationConfigRequest {
 		ExternalLocation:     dc.externalLocation,
 		AuthType:             dc.authType,
 		RoleArn:              dc.roleArn,
+		SecretKey:			  dc.secretKey,
 	}
 }
 
@@ -197,5 +201,10 @@ func (dc *DestinationConfig) AuthType(value string) *DestinationConfig {
 
 func (dc *DestinationConfig) RoleArn(value string) *DestinationConfig {
 	dc.roleArn = &value
+	return dc
+}
+
+func (dc *DestinationConfig) SecretKey(value string) *DestinationConfig {
+	dc.secretKey = &value
 	return dc
 }


### PR DESCRIPTION
Add missing request/response field for destinations management