### PR TITLE
User-Agent headers added to each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.2.1...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.2.2...HEAD)
+
+## [0.2.3](https://github.com/fivetran/go-fivetran/compare/v0.2.2...v0.2.3) - 2021-11-10
+
+### Added
+- `UserAgent` method for overriding User-Agent header in http-responses (for terraform-provider)
 
 ## [0.2.2](https://github.com/fivetran/go-fivetran/compare/v0.2.1...v0.2.2) - 2021-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.2.2...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.2.3...HEAD)
 
 ## [0.2.3](https://github.com/fivetran/go-fivetran/compare/v0.2.2...v0.2.3) - 2021-11-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.2.3](https://github.com/fivetran/go-fivetran/compare/v0.2.2...v0.2.3) - 2021-11-10
 
 ### Added
-- `UserAgent` method for overriding User-Agent header in http-responses (for terraform-provider)
+- `CustomUserAgent` method for overriding User-Agent header in http-responses (for terraform-provider)
 
 ## [0.2.2](https://github.com/fivetran/go-fivetran/compare/v0.2.1...v0.2.2) - 2021-09-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.2.3...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.3.0...HEAD)
 
-## [0.2.3](https://github.com/fivetran/go-fivetran/compare/v0.2.2...v0.2.3) - 2021-11-10
+## [0.3.0](https://github.com/fivetran/go-fivetran/compare/v0.2.2...v0.3.0) - 2021-11-10
 
 ### Added
-- `CustomUserAgent` method for overriding User-Agent header in http-responses (for terraform-provider)
+- `CustomUserAgent` method for overriding User-Agent header in http-responses (for applications that uses SDK)
 
 ## [0.2.2](https://github.com/fivetran/go-fivetran/compare/v0.2.1...v0.2.2) - 2021-09-22
 

--- a/certificate_connector_certificate_approve.go
+++ b/certificate_connector_certificate_approve.go
@@ -58,8 +58,7 @@ func (s *CertificateConnectorCertificateApproveService) Do(ctx context.Context) 
 	url := fmt.Sprintf("%v/certificates", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_connector_certificate_approve.go
+++ b/certificate_connector_certificate_approve.go
@@ -58,7 +58,7 @@ func (s *CertificateConnectorCertificateApproveService) Do(ctx context.Context) 
 	url := fmt.Sprintf("%v/certificates", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_connector_fingerprint_approve.go
+++ b/certificate_connector_fingerprint_approve.go
@@ -58,8 +58,7 @@ func (s *CertificateConnectorFingerprintApproveService) Do(ctx context.Context) 
 	url := fmt.Sprintf("%v/fingerprints", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_connector_fingerprint_approve.go
+++ b/certificate_connector_fingerprint_approve.go
@@ -58,7 +58,7 @@ func (s *CertificateConnectorFingerprintApproveService) Do(ctx context.Context) 
 	url := fmt.Sprintf("%v/fingerprints", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_destination_certificate_approve.go
+++ b/certificate_destination_certificate_approve.go
@@ -58,7 +58,7 @@ func (s *CertificateDestinationCertificateApproveService) Do(ctx context.Context
 	url := fmt.Sprintf("%v/certificates", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_destination_certificate_approve.go
+++ b/certificate_destination_certificate_approve.go
@@ -58,8 +58,7 @@ func (s *CertificateDestinationCertificateApproveService) Do(ctx context.Context
 	url := fmt.Sprintf("%v/certificates", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_destination_fingerprint_approve.go
+++ b/certificate_destination_fingerprint_approve.go
@@ -58,8 +58,7 @@ func (s *CertificateDestinationFingerprintApproveService) Do(ctx context.Context
 	url := fmt.Sprintf("%v/fingerprints", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/certificate_destination_fingerprint_approve.go
+++ b/certificate_destination_fingerprint_approve.go
@@ -58,7 +58,7 @@ func (s *CertificateDestinationFingerprintApproveService) Do(ctx context.Context
 	url := fmt.Sprintf("%v/fingerprints", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/client.go
+++ b/client.go
@@ -37,9 +37,9 @@ func (c *Client) UserAgent(userAgent string) {
 	c.userAgent = userAgent
 }
 
-func (c *Client) fillHeaders() map[string]string {
-	headers := make(map[string]string)
-	headers["Authorization"] = c.authorization
-	headers["User-Agent"] = c.userAgent
-	return headers
+func (c *Client) commonHeaders() map[string]string {
+	return map[string]string{
+		"Authorization": c.authorization,
+		"User-Agent":    c.userAgent,
+	}
 }

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
 
 // WARNING: Update Agent version on each release!
-const defaultUserAgent = "Go-Fivetran/0.2.3"
+const defaultUserAgent = "Go-Fivetran/0.3.0"
 
 // New receives API Key and API Secret, and returns a new Client
 func New(apiKey, apiSecret string) *Client {

--- a/client.go
+++ b/client.go
@@ -21,9 +21,8 @@ const defaultUserAgent = "Go-Fivetran/0.2.3"
 // New receives API Key and API Secret, and returns a new Client
 func New(apiKey, apiSecret string) *Client {
 	return &Client{
-		baseURL:         defaultBaseURL,
-		authorization:   fmt.Sprintf("Basic %v", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", apiKey, apiSecret)))),
-		customUserAgent: "",
+		baseURL:       defaultBaseURL,
+		authorization: fmt.Sprintf("Basic %v", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", apiKey, apiSecret)))),
 	}
 }
 
@@ -32,7 +31,7 @@ func (c *Client) BaseURL(baseURL string) {
 	c.baseURL = baseURL
 }
 
-// UserAgent sets custom User-Agent header in Client requests
+// CustomUserAgent sets custom User-Agent header in Client requests
 func (c *Client) CustomUserAgent(customUserAgent string) {
 	c.customUserAgent = customUserAgent
 }

--- a/client.go
+++ b/client.go
@@ -7,9 +7,9 @@ import (
 
 // Client holds client configuration
 type Client struct {
-	baseURL       string
-	authorization string
-	userAgent     string
+	baseURL         string
+	authorization   string
+	customUserAgent string
 }
 
 const defaultBaseURL = "https://api.fivetran.com/v1"
@@ -21,9 +21,9 @@ const defaultUserAgent = "Go-Fivetran/0.2.3"
 // New receives API Key and API Secret, and returns a new Client
 func New(apiKey, apiSecret string) *Client {
 	return &Client{
-		baseURL:       defaultBaseURL,
-		authorization: fmt.Sprintf("Basic %v", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", apiKey, apiSecret)))),
-		userAgent:     defaultUserAgent,
+		baseURL:         defaultBaseURL,
+		authorization:   fmt.Sprintf("Basic %v", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", apiKey, apiSecret)))),
+		customUserAgent: "",
 	}
 }
 
@@ -33,13 +33,19 @@ func (c *Client) BaseURL(baseURL string) {
 }
 
 // UserAgent sets custom User-Agent header in Client requests
-func (c *Client) UserAgent(userAgent string) {
-	c.userAgent = userAgent
+func (c *Client) CustomUserAgent(customUserAgent string) {
+	c.customUserAgent = customUserAgent
 }
 
 func (c *Client) commonHeaders() map[string]string {
+	userAgent := defaultUserAgent
+
+	if c.customUserAgent != "" {
+		userAgent += " " + c.customUserAgent
+	}
+
 	return map[string]string{
 		"Authorization": c.authorization,
-		"User-Agent":    c.userAgent,
+		"User-Agent":    userAgent,
 	}
 }

--- a/client.go
+++ b/client.go
@@ -9,20 +9,37 @@ import (
 type Client struct {
 	baseURL       string
 	authorization string
+	userAgent     string
 }
 
 const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
+
+// WARNING: Update Agent version on each release!
+const defaultUserAgent = "Go-Fivetran/0.2.3"
 
 // New receives API Key and API Secret, and returns a new Client
 func New(apiKey, apiSecret string) *Client {
 	return &Client{
 		baseURL:       defaultBaseURL,
 		authorization: fmt.Sprintf("Basic %v", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", apiKey, apiSecret)))),
+		userAgent:     defaultUserAgent,
 	}
 }
 
 // BaseURL changes Client base REST API endpoint URL
 func (c *Client) BaseURL(baseURL string) {
 	c.baseURL = baseURL
+}
+
+// UserAgent sets custom User-Agent header in Client requests
+func (c *Client) UserAgent(userAgent string) {
+	c.userAgent = userAgent
+}
+
+func (c *Client) fillHeaders() map[string]string {
+	headers := make(map[string]string)
+	headers["Authorization"] = c.authorization
+	headers["User-Agent"] = c.userAgent
+	return headers
 }

--- a/connector_create.go
+++ b/connector_create.go
@@ -169,7 +169,7 @@ func (s *ConnectorCreateService) Do(ctx context.Context) (ConnectorCreateRespons
 	url := fmt.Sprintf("%v/connectors", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 	headers["Accept"] = restAPIv2
 

--- a/connector_create.go
+++ b/connector_create.go
@@ -169,8 +169,7 @@ func (s *ConnectorCreateService) Do(ctx context.Context) (ConnectorCreateRespons
 	url := fmt.Sprintf("%v/connectors", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 	headers["Accept"] = restAPIv2
 

--- a/connector_delete.go
+++ b/connector_delete.go
@@ -37,7 +37,7 @@ func (s *ConnectorDeleteService) Do(ctx context.Context) (ConnectorDeleteRespons
 	url := fmt.Sprintf("%v/connectors/%v", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/connector_delete.go
+++ b/connector_delete.go
@@ -37,8 +37,7 @@ func (s *ConnectorDeleteService) Do(ctx context.Context) (ConnectorDeleteRespons
 	url := fmt.Sprintf("%v/connectors/%v", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/connector_details.go
+++ b/connector_details.go
@@ -70,7 +70,7 @@ func (s *ConnectorDetailsService) Do(ctx context.Context) (ConnectorDetailsRespo
 	url := fmt.Sprintf("%v/connectors/%v", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Accept"] = restAPIv2
 
 	r := request{

--- a/connector_details.go
+++ b/connector_details.go
@@ -70,8 +70,7 @@ func (s *ConnectorDetailsService) Do(ctx context.Context) (ConnectorDetailsRespo
 	url := fmt.Sprintf("%v/connectors/%v", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Accept"] = restAPIv2
 
 	r := request{

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -179,7 +179,7 @@ func (s *ConnectorModifyService) Do(ctx context.Context) (ConnectorModifyRespons
 	url := fmt.Sprintf("%v/connectors/%v", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 	headers["Accept"] = restAPIv2
 

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -179,8 +179,7 @@ func (s *ConnectorModifyService) Do(ctx context.Context) (ConnectorModifyRespons
 	url := fmt.Sprintf("%v/connectors/%v", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 	headers["Accept"] = restAPIv2
 

--- a/connector_resync_table.go
+++ b/connector_resync_table.go
@@ -55,7 +55,7 @@ func (s *ConnectorReSyncTableService) Do(ctx context.Context) (ConnectorReSyncTa
 	url := fmt.Sprintf("%v/connectors/%v/schemas/%v/tables/%v/resync", s.c.baseURL, *s.connectorID, *s.schema, *s.table)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "POST",

--- a/connector_resync_table.go
+++ b/connector_resync_table.go
@@ -55,8 +55,7 @@ func (s *ConnectorReSyncTableService) Do(ctx context.Context) (ConnectorReSyncTa
 	url := fmt.Sprintf("%v/connectors/%v/schemas/%v/tables/%v/resync", s.c.baseURL, *s.connectorID, *s.schema, *s.table)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "POST",

--- a/connector_setup_tests.go
+++ b/connector_setup_tests.go
@@ -95,8 +95,7 @@ func (s *ConnectorSetupTestsService) Do(ctx context.Context) (ConnectorSetupTest
 	url := fmt.Sprintf("%v/connectors/%v/test", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 	headers["Accept"] = restAPIv2
 

--- a/connector_setup_tests.go
+++ b/connector_setup_tests.go
@@ -95,7 +95,7 @@ func (s *ConnectorSetupTestsService) Do(ctx context.Context) (ConnectorSetupTest
 	url := fmt.Sprintf("%v/connectors/%v/test", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 	headers["Accept"] = restAPIv2
 

--- a/connector_sync.go
+++ b/connector_sync.go
@@ -37,8 +37,7 @@ func (s *ConnectorSyncService) Do(ctx context.Context) (ConnectorSyncResponse, e
 	url := fmt.Sprintf("%v/connectors/%v/force", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s)

--- a/connector_sync.go
+++ b/connector_sync.go
@@ -37,7 +37,7 @@ func (s *ConnectorSyncService) Do(ctx context.Context) (ConnectorSyncResponse, e
 	url := fmt.Sprintf("%v/connectors/%v/force", s.c.baseURL, *s.connectorID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s)

--- a/connectors_source_metadata.go
+++ b/connectors_source_metadata.go
@@ -50,7 +50,7 @@ func (s *ConnectorsSourceMetadataService) Do(ctx context.Context) (ConnectorsSou
 	url := fmt.Sprintf("%v/metadata/connectors", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/connectors_source_metadata.go
+++ b/connectors_source_metadata.go
@@ -50,8 +50,7 @@ func (s *ConnectorsSourceMetadataService) Do(ctx context.Context) (ConnectorsSou
 	url := fmt.Sprintf("%v/metadata/connectors", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/destination_create.go
+++ b/destination_create.go
@@ -118,8 +118,7 @@ func (s *DestinationCreateService) Do(ctx context.Context) (DestinationCreateRes
 	url := fmt.Sprintf("%v/destinations", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/destination_create.go
+++ b/destination_create.go
@@ -118,7 +118,7 @@ func (s *DestinationCreateService) Do(ctx context.Context) (DestinationCreateRes
 	url := fmt.Sprintf("%v/destinations", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/destination_delete.go
+++ b/destination_delete.go
@@ -37,7 +37,7 @@ func (s *DestinationDeleteService) Do(ctx context.Context) (DestinationDeleteRes
 	url := fmt.Sprintf("%v/destinations/%v", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/destination_delete.go
+++ b/destination_delete.go
@@ -37,8 +37,7 @@ func (s *DestinationDeleteService) Do(ctx context.Context) (DestinationDeleteRes
 	url := fmt.Sprintf("%v/destinations/%v", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/destination_details.go
+++ b/destination_details.go
@@ -46,8 +46,7 @@ func (s *DestinationDetailsService) Do(ctx context.Context) (DestinationDetailsR
 	url := fmt.Sprintf("%v/destinations/%v", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "GET",

--- a/destination_details.go
+++ b/destination_details.go
@@ -46,7 +46,7 @@ func (s *DestinationDetailsService) Do(ctx context.Context) (DestinationDetailsR
 	url := fmt.Sprintf("%v/destinations/%v", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "GET",

--- a/destination_modify.go
+++ b/destination_modify.go
@@ -113,7 +113,7 @@ func (s *DestinationModifyService) Do(ctx context.Context) (DestinationModifyRes
 	url := fmt.Sprintf("%v/destinations/%v", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/destination_modify.go
+++ b/destination_modify.go
@@ -113,8 +113,7 @@ func (s *DestinationModifyService) Do(ctx context.Context) (DestinationModifyRes
 	url := fmt.Sprintf("%v/destinations/%v", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/destination_setup_tests.go
+++ b/destination_setup_tests.go
@@ -75,8 +75,7 @@ func (s *DestinationSetupTestsService) Do(ctx context.Context) (DestinationSetup
 	url := fmt.Sprintf("%v/destinations/%v/test", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/destination_setup_tests.go
+++ b/destination_setup_tests.go
@@ -75,7 +75,7 @@ func (s *DestinationSetupTestsService) Do(ctx context.Context) (DestinationSetup
 	url := fmt.Sprintf("%v/destinations/%v/test", s.c.baseURL, *s.destinationID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_add_user.go
+++ b/group_add_user.go
@@ -61,7 +61,7 @@ func (s *GroupAddUserService) Do(ctx context.Context) (GroupAddUserResponse, err
 	url := fmt.Sprintf("%v/groups/%v/users", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_add_user.go
+++ b/group_add_user.go
@@ -61,8 +61,7 @@ func (s *GroupAddUserService) Do(ctx context.Context) (GroupAddUserResponse, err
 	url := fmt.Sprintf("%v/groups/%v/users", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_create.go
+++ b/group_create.go
@@ -48,8 +48,7 @@ func (s *GroupCreateService) Do(ctx context.Context) (GroupCreateResponse, error
 	url := fmt.Sprintf("%v/groups", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_create.go
+++ b/group_create.go
@@ -48,7 +48,7 @@ func (s *GroupCreateService) Do(ctx context.Context) (GroupCreateResponse, error
 	url := fmt.Sprintf("%v/groups", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_delete.go
+++ b/group_delete.go
@@ -37,8 +37,7 @@ func (s *GroupDeleteService) Do(ctx context.Context) (groupDeleteResponse, error
 	url := fmt.Sprintf("%v/groups/%v", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/group_delete.go
+++ b/group_delete.go
@@ -37,7 +37,7 @@ func (s *GroupDeleteService) Do(ctx context.Context) (groupDeleteResponse, error
 	url := fmt.Sprintf("%v/groups/%v", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/group_details.go
+++ b/group_details.go
@@ -43,8 +43,7 @@ func (s *GroupDetailsService) Do(ctx context.Context) (GroupDetailsResponse, err
 	url := fmt.Sprintf("%v/groups/%v", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "GET",

--- a/group_details.go
+++ b/group_details.go
@@ -43,7 +43,7 @@ func (s *GroupDetailsService) Do(ctx context.Context) (GroupDetailsResponse, err
 	url := fmt.Sprintf("%v/groups/%v", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "GET",

--- a/group_list_connectors.go
+++ b/group_list_connectors.go
@@ -87,8 +87,7 @@ func (s *GroupListConnectorsService) Do(ctx context.Context) (GroupListConnector
 	url := fmt.Sprintf("%v/groups/%v/connectors", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/group_list_connectors.go
+++ b/group_list_connectors.go
@@ -87,7 +87,7 @@ func (s *GroupListConnectorsService) Do(ctx context.Context) (GroupListConnector
 	url := fmt.Sprintf("%v/groups/%v/connectors", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/group_list_users.go
+++ b/group_list_users.go
@@ -66,7 +66,7 @@ func (s *GroupListUsersService) Do(ctx context.Context) (GroupListUsersResponse,
 	url := fmt.Sprintf("%v/groups/%v/users", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/group_list_users.go
+++ b/group_list_users.go
@@ -66,8 +66,7 @@ func (s *GroupListUsersService) Do(ctx context.Context) (GroupListUsersResponse,
 	url := fmt.Sprintf("%v/groups/%v/users", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/group_modify.go
+++ b/group_modify.go
@@ -59,7 +59,7 @@ func (s *GroupModifyService) Do(ctx context.Context) (GroupModifyResponse, error
 	url := fmt.Sprintf("%v/groups/%v", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_modify.go
+++ b/group_modify.go
@@ -59,8 +59,7 @@ func (s *GroupModifyService) Do(ctx context.Context) (GroupModifyResponse, error
 	url := fmt.Sprintf("%v/groups/%v", s.c.baseURL, *s.groupID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/group_remove_user.go
+++ b/group_remove_user.go
@@ -46,7 +46,7 @@ func (s *GroupRemoveUserService) Do(ctx context.Context) (GroupRemoveUserRespons
 	url := fmt.Sprintf("%v/groups/%v/users/%v", s.c.baseURL, *s.groupID, *s.userID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/group_remove_user.go
+++ b/group_remove_user.go
@@ -46,8 +46,7 @@ func (s *GroupRemoveUserService) Do(ctx context.Context) (GroupRemoveUserRespons
 	url := fmt.Sprintf("%v/groups/%v/users/%v", s.c.baseURL, *s.groupID, *s.userID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/groups_list.go
+++ b/groups_list.go
@@ -47,7 +47,7 @@ func (s *GroupsListService) Do(ctx context.Context) (GroupsListResponse, error) 
 	url := fmt.Sprintf("%v/groups", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/groups_list.go
+++ b/groups_list.go
@@ -47,8 +47,7 @@ func (s *GroupsListService) Do(ctx context.Context) (GroupsListResponse, error) 
 	url := fmt.Sprintf("%v/groups", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/user_delete.go
+++ b/user_delete.go
@@ -37,8 +37,7 @@ func (s *UserDeleteService) Do(ctx context.Context) (userDeleteResponse, error) 
 	url := fmt.Sprintf("%v/users/%v", s.c.baseURL, *s.userID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/user_delete.go
+++ b/user_delete.go
@@ -37,7 +37,7 @@ func (s *UserDeleteService) Do(ctx context.Context) (userDeleteResponse, error) 
 	url := fmt.Sprintf("%v/users/%v", s.c.baseURL, *s.userID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "DELETE",

--- a/user_details.go
+++ b/user_details.go
@@ -50,8 +50,7 @@ func (s *UserDetailsService) Do(ctx context.Context) (UserDetailsResponse, error
 	url := fmt.Sprintf("%v/users/%v", s.c.baseURL, *s.userID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	r := request{
 		method:  "GET",

--- a/user_details.go
+++ b/user_details.go
@@ -50,7 +50,7 @@ func (s *UserDetailsService) Do(ctx context.Context) (UserDetailsResponse, error
 	url := fmt.Sprintf("%v/users/%v", s.c.baseURL, *s.userID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	r := request{
 		method:  "GET",

--- a/user_invite.go
+++ b/user_invite.go
@@ -95,8 +95,7 @@ func (s *UserInviteService) Do(ctx context.Context) (UserInviteResponse, error) 
 	url := fmt.Sprintf("%v/users", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/user_invite.go
+++ b/user_invite.go
@@ -95,7 +95,7 @@ func (s *UserInviteService) Do(ctx context.Context) (UserInviteResponse, error) 
 	url := fmt.Sprintf("%v/users", s.c.baseURL)
 	expectedStatus := 201
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/user_modify.go
+++ b/user_modify.go
@@ -98,7 +98,7 @@ func (s *UserModifyService) Do(ctx context.Context) (UserModifyResponse, error) 
 	url := fmt.Sprintf("%v/users/%v", s.c.baseURL, *s.userID)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/user_modify.go
+++ b/user_modify.go
@@ -98,8 +98,7 @@ func (s *UserModifyService) Do(ctx context.Context) (UserModifyResponse, error) 
 	url := fmt.Sprintf("%v/users/%v", s.c.baseURL, *s.userID)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 	headers["Content-Type"] = "application/json"
 
 	reqBody, err := json.Marshal(s.request())

--- a/users_list.go
+++ b/users_list.go
@@ -55,7 +55,7 @@ func (s *UsersListService) Do(ctx context.Context) (UsersListResponse, error) {
 	url := fmt.Sprintf("%v/users", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := s.c.fillHeaders()
+	headers := s.c.commonHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {

--- a/users_list.go
+++ b/users_list.go
@@ -55,8 +55,7 @@ func (s *UsersListService) Do(ctx context.Context) (UsersListResponse, error) {
 	url := fmt.Sprintf("%v/users", s.c.baseURL)
 	expectedStatus := 200
 
-	headers := make(map[string]string)
-	headers["Authorization"] = s.c.authorization
+	headers := s.c.fillHeaders()
 
 	queries := make(map[string]string)
 	if s.cursor != nil {


### PR DESCRIPTION
Related to [T-135809](https://fivetran.height.app/T-135809)

To provide information about our API usage we should add User-Agent headers to requests to identify requests from Go-Fivetran and Terraform.

Client.UserAgent method allows to set-up custom User-Agent header - this method will be used by terraform provider.
By default header will be: "User-Agent":"Go-Fivetran/<version>" 

changes tested on local environment via examples.