### PR TITLE
Fix `connection_method` usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.4.0...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.5.1...HEAD)
+
+## [0.5.1](https://github.com/fivetran/go-fivetran/compare/v0.4.0...v0.5.0) - 2022-01-31
+
+## Fixed
+Use `connection_type` in destinations responses instead of `connection_method` due to fixed missconsistency.
 
 ## [0.5.0](https://github.com/fivetran/go-fivetran/compare/v0.4.0...v0.5.0) - 2022-01-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.4.0...HEAD)
 
+## [0.5.0](https://github.com/fivetran/go-fivetran/compare/v0.4.0...v0.5.0) - 2022-01-24
+
+## Added
+The following fields were added to user resource responses
+- UserDetailsResponse.Data.Role - RoleName for user role in account
+- UserInviteResponse.Data.Role - RoleName for user role in account
+- UserModifyResponse.Data.Role - RoleName for user role in account
+
 ## [0.4.0](https://github.com/fivetran/go-fivetran/compare/v0.3.1...v0.4.0) - 2022-01-18
 
 ## Added

--- a/destination_config.go
+++ b/destination_config.go
@@ -61,7 +61,7 @@ type DestinationConfigResponse struct {
 	Auth                 string `json:"auth"`
 	User                 string `json:"user"`
 	Password             string `json:"password"`
-	ConnectionMethod     string `json:"connection_method"` // ConnectionMethod is the REST API's response of ConnectionType. T-111758
+	ConnectionType       string `json:"connection_type"` // ConnectionMethod is the REST API's response of ConnectionType. T-111758
 	TunnelHost           string `json:"tunnel_host"`
 	TunnelPort           string `json:"tunnel_port"`
 	TunnelUser           string `json:"tunnel_user"`

--- a/destination_create.go
+++ b/destination_create.go
@@ -120,6 +120,7 @@ func (s *DestinationCreateService) Do(ctx context.Context) (DestinationCreateRes
 
 	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
+	headers["Accept"] = restAPIv2
 
 	reqBody, err := json.Marshal(s.request())
 	if err != nil {

--- a/destination_details.go
+++ b/destination_details.go
@@ -47,6 +47,7 @@ func (s *DestinationDetailsService) Do(ctx context.Context) (DestinationDetailsR
 	expectedStatus := 200
 
 	headers := s.c.commonHeaders()
+	headers["Accept"] = restAPIv2
 
 	r := request{
 		method:  "GET",

--- a/destination_modify.go
+++ b/destination_modify.go
@@ -115,6 +115,7 @@ func (s *DestinationModifyService) Do(ctx context.Context) (DestinationModifyRes
 
 	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
+	headers["Accept"] = restAPIv2
 
 	reqBody, err := json.Marshal(s.request())
 	if err != nil {

--- a/destination_setup_tests.go
+++ b/destination_setup_tests.go
@@ -77,6 +77,7 @@ func (s *DestinationSetupTestsService) Do(ctx context.Context) (DestinationSetup
 
 	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
+	headers["Accept"] = restAPIv2
 
 	reqBody, err := json.Marshal(s.request())
 	if err != nil {

--- a/user_details.go
+++ b/user_details.go
@@ -28,6 +28,7 @@ type UserDetailsResponse struct {
 		Phone      string    `json:"phone"`
 		LoggedInAt time.Time `json:"logged_in_at"`
 		CreatedAt  time.Time `json:"created_at"`
+		Role	   string    `json:"role"`
 	} `json:"data"`
 }
 

--- a/user_invite.go
+++ b/user_invite.go
@@ -42,6 +42,7 @@ type UserInviteResponse struct {
 		Phone      string    `json:"phone"`
 		LoggedInAt time.Time `json:"logged_in_at"`
 		CreatedAt  time.Time `json:"created_at"`
+		Role	   string    `json:"role"`
 	} `json:"data"`
 }
 

--- a/user_modify.go
+++ b/user_modify.go
@@ -41,6 +41,7 @@ type UserModifyResponse struct {
 		Phone      string    `json:"phone"`
 		LoggedInAt time.Time `json:"logged_in_at"`
 		CreatedAt  time.Time `json:"created_at"`
+		Role	   string    `json:"role"`
 	} `json:"data"`
 }
 


### PR DESCRIPTION
Now we can use `connection_type` in both request and response config objects for destinations with Accept:"version=2" header.