### PR TITLE
Fix: Unmarshalling error for  config field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+.vscode

--- a/destination_config.go
+++ b/destination_config.go
@@ -71,7 +71,7 @@ type DestinationConfigResponse struct {
 	ServerHostName       string `json:"server_host_name"`
 	HTTPPath             string `json:"http_path"`
 	PersonalAccessToken  string `json:"personal_access_token"`
-	CreateExternalTables *bool  `json:"create_external_tables"`
+	CreateExternalTables string `json:"create_external_tables"`
 	ExternalLocation     string `json:"external_location"`
 	AuthType             string `json:"auth_type"`
 	RoleArn              string `json:"role_arn"`


### PR DESCRIPTION
The fix covers an issue we came across and reported [here](https://support.fivetran.com/hc/en-us/requests/88748)

I did test the change by making changes to `destination_details_test.go` to get a destination of our own. PFA screenshots for more context.

![image](https://user-images.githubusercontent.com/11011852/169937043-43d77528-21d4-4930-95cf-a890f8083059.png)
