### PR TITLE
Connector Schema Config minimal support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.5.11...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.6.0...HEAD)
+
+## [0.6.0](https://github.com/fivetran/go-fivetran/compare/v0.5.11...v0.6.0) - 2022-07-08
+
+## Added
+Supported the following Fivetran API endpoints:
+- [Retrieve a Connector Schema Config](https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig)
+- [Reload a Connector Schema Config](https://fivetran.com/docs/rest-api/connectors#reloadaconnectorschemaconfig)
+- [Modify a Connector Schema Config](https://fivetran.com/docs/rest-api/connectors#modifyaconnectorschemaconfig)
 
 ## [0.5.11](https://github.com/fivetran/go-fivetran/compare/v0.5.10...v0.5.11) - 2022-07-05
 

--- a/connector_schema_config_column.go
+++ b/connector_schema_config_column.go
@@ -1,0 +1,43 @@
+package fivetran
+
+type ConnectorSchemaConfigColumn struct {
+	enabled *bool
+	hashed  *bool
+}
+
+type connectorSchemaConfigColumnRequest struct {
+	Enabled *bool `json:"enabled,omitempty"`
+	Hashed  *bool `json:"hashed,omitempty"`
+}
+
+type ConnectorSchemaConfigColumnResponse struct {
+	NameInDestination    *string `json:"name_in_destination"`
+	Enabled              *bool   `json:"enabled"`
+	Hashed               *bool   `json:"hashed"`
+	EnabledPatchSettings struct {
+		Allowed    *bool   `json:"allowed"`
+		ReasonCode *string `json:"reason_code"`
+		Reason     *string `json:"reason"`
+	} `json:"enabled_patch_settings"`
+}
+
+func NewConnectorSchemaConfigColumn() *ConnectorSchemaConfigColumn {
+	return &ConnectorSchemaConfigColumn{}
+}
+
+func (csc *ConnectorSchemaConfigColumn) request() *connectorSchemaConfigColumnRequest {
+	return &connectorSchemaConfigColumnRequest{
+		Enabled: csc.enabled,
+		Hashed:  csc.hashed,
+	}
+}
+
+func (csc *ConnectorSchemaConfigColumn) Enabled(value bool) *ConnectorSchemaConfigColumn {
+	csc.enabled = &value
+	return csc
+}
+
+func (csc *ConnectorSchemaConfigColumn) Hashed(value bool) *ConnectorSchemaConfigColumn {
+	csc.hashed = &value
+	return csc
+}

--- a/connector_schema_config_reload.go
+++ b/connector_schema_config_reload.go
@@ -1,0 +1,85 @@
+package fivetran
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ConnectorSchemaReloadService implements the Connector Management, Reload a Connector Schema Config API.
+// Ref. https://fivetran.com/docs/rest-api/connectors#reloadaconnectorschemaconfig
+type ConnectorSchemaReloadService struct {
+	c           *Client
+	connectorID *string
+	excludeMode *string
+}
+
+type connectorSchemaReloadRequest struct {
+	ExcludeMode *string `json:"exclude_mode,omitempty"`
+}
+
+func (c *Client) NewConnectorSchemaReload() *ConnectorSchemaReloadService {
+	return &ConnectorSchemaReloadService{c: c}
+}
+
+func (s *ConnectorSchemaReloadService) request() *connectorSchemaReloadRequest {
+	mode := "PRESERVE"
+	if s.excludeMode != nil {
+		mode = *s.excludeMode
+	}
+	return &connectorSchemaReloadRequest{ExcludeMode: &mode}
+}
+
+func (s *ConnectorSchemaReloadService) ConnectorID(value string) *ConnectorSchemaReloadService {
+	s.connectorID = &value
+	return s
+}
+
+func (s *ConnectorSchemaReloadService) ExcludeMode(value string) *ConnectorSchemaReloadService {
+	s.excludeMode = &value
+	return s
+}
+
+func (s *ConnectorSchemaReloadService) Do(ctx context.Context) (ConnectorSchemaDetailsResponse, error) {
+	var response ConnectorSchemaDetailsResponse
+
+	if s.connectorID == nil {
+		return response, fmt.Errorf("missing required ConnectorID")
+	}
+
+	reqBody, err := json.Marshal(s.request())
+	if err != nil {
+		return response, err
+	}
+
+	url := fmt.Sprintf("%v/connectors/%v/schemas/reload", s.c.baseURL, *s.connectorID)
+	expectedStatus := 200
+
+	headers := s.c.commonHeaders()
+	headers["Content-Type"] = "application/json"
+	headers["Accept"] = restAPIv2
+
+	r := request{
+		method:  "POST",
+		url:     url,
+		body:    reqBody,
+		queries: nil,
+		headers: headers,
+	}
+
+	respBody, respStatus, err := httpRequest(r, ctx)
+	if err != nil {
+		return response, err
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return response, err
+	}
+
+	if respStatus != expectedStatus {
+		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
+		return response, err
+	}
+
+	return response, nil
+}

--- a/connector_schema_config_schema.go
+++ b/connector_schema_config_schema.go
@@ -1,0 +1,48 @@
+package fivetran
+
+type ConnectorSchemaConfigSchema struct {
+	enabled *bool
+	tables  map[string]*ConnectorSchemaConfigTable
+}
+
+type connectorSchemaConfigSchemaRequest struct {
+	Enabled *bool                                         `json:"enabled,omitempty"`
+	Tables  map[string]*connectorSchemaConfigTableRequest `json:"tables,omitempty"`
+}
+
+type ConnectorSchemaConfigSchemaResponse struct {
+	Enabled *bool                                          `json:"enabled"`
+	Tables  map[string]*connectorSchemaConfigTableResponse `json:"tables"`
+}
+
+func NewConnectorSchemaConfigSchema() *ConnectorSchemaConfigSchema {
+	return &ConnectorSchemaConfigSchema{}
+}
+
+func (css *ConnectorSchemaConfigSchema) request() *connectorSchemaConfigSchemaRequest {
+	var tables map[string]*connectorSchemaConfigTableRequest
+	if css.tables != nil && len(css.tables) != 0 {
+		tables = make(map[string]*connectorSchemaConfigTableRequest)
+		for k, v := range css.tables {
+			tables[k] = v.request()
+		}
+	}
+
+	return &connectorSchemaConfigSchemaRequest{
+		Enabled: css.enabled,
+		Tables:  tables,
+	}
+}
+
+func (css *ConnectorSchemaConfigSchema) Enabled(value bool) *ConnectorSchemaConfigSchema {
+	css.enabled = &value
+	return css
+}
+
+func (css *ConnectorSchemaConfigSchema) Table(name string, table *ConnectorSchemaConfigTable) *ConnectorSchemaConfigSchema {
+	if css.tables == nil {
+		css.tables = make(map[string]*ConnectorSchemaConfigTable)
+	}
+	css.tables[name] = table
+	return css
+}

--- a/connector_schema_config_table.go
+++ b/connector_schema_config_table.go
@@ -1,0 +1,48 @@
+package fivetran
+
+type ConnectorSchemaConfigTable struct {
+	enabled *bool
+	columns map[string]*ConnectorSchemaConfigColumn
+}
+
+type connectorSchemaConfigTableRequest struct {
+	Enabled *bool                                          `json:"enabled,omitempty"`
+	Columns map[string]*connectorSchemaConfigColumnRequest `json:"columns,omitempty"`
+}
+
+type connectorSchemaConfigTableResponse struct {
+	Enabled *bool                                           `json:"enabled"`
+	Columns map[string]*ConnectorSchemaConfigColumnResponse `json:"columns"`
+}
+
+func NewConnectorSchemaConfigTable() *ConnectorSchemaConfigTable {
+	return &ConnectorSchemaConfigTable{}
+}
+
+func (cst *ConnectorSchemaConfigTable) request() *connectorSchemaConfigTableRequest {
+	var columns map[string]*connectorSchemaConfigColumnRequest
+	if cst.columns != nil && len(cst.columns) != 0 {
+		columns = make(map[string]*connectorSchemaConfigColumnRequest)
+		for k, v := range cst.columns {
+			columns[k] = v.request()
+		}
+	}
+
+	return &connectorSchemaConfigTableRequest{
+		Enabled: cst.enabled,
+		Columns: columns,
+	}
+}
+
+func (cst *ConnectorSchemaConfigTable) Enabled(value bool) *ConnectorSchemaConfigTable {
+	cst.enabled = &value
+	return cst
+}
+
+func (cst *ConnectorSchemaConfigTable) Column(name string, value *ConnectorSchemaConfigColumn) *ConnectorSchemaConfigTable {
+	if cst.columns == nil {
+		cst.columns = make(map[string]*ConnectorSchemaConfigColumn)
+	}
+	cst.columns[name] = value
+	return cst
+}

--- a/connector_schema_config_update.go
+++ b/connector_schema_config_update.go
@@ -1,0 +1,102 @@
+package fivetran
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ConnectorSchemaConfigUpdateService implements the Connector Management, Modify a Connector Schema Config API.
+// Ref. https://fivetran.com/docs/rest-api/connectors#modifyaconnectorschemaconfig
+type ConnectorSchemaConfigUpdateService struct {
+	c                    *Client
+	connectorID          *string
+	schemaChangeHandling *string
+	schemas              map[string]*ConnectorSchemaConfigSchema
+}
+
+type connectorSchemaConfigUpdateRequest struct {
+	SchemaChangeHandling *string                                        `json:"schema_change_handling,omitempty"`
+	Schemas              map[string]*connectorSchemaConfigSchemaRequest `json:"schemas,omitempty"`
+}
+
+func (c *Client) NewConnectorSchemaUpdateService() *ConnectorSchemaConfigUpdateService {
+	return &ConnectorSchemaConfigUpdateService{c: c}
+}
+
+func (csu *ConnectorSchemaConfigUpdateService) request() *connectorSchemaConfigUpdateRequest {
+	var schemas map[string]*connectorSchemaConfigSchemaRequest
+	if csu.schemas != nil && len(csu.schemas) != 0 {
+		schemas = make(map[string]*connectorSchemaConfigSchemaRequest)
+		for k, v := range csu.schemas {
+			schemas[k] = v.request()
+		}
+	}
+
+	return &connectorSchemaConfigUpdateRequest{
+		SchemaChangeHandling: csu.schemaChangeHandling,
+		Schemas:              schemas,
+	}
+}
+
+func (csu *ConnectorSchemaConfigUpdateService) ConnectorID(value string) *ConnectorSchemaConfigUpdateService {
+	csu.connectorID = &value
+	return csu
+}
+
+func (csu *ConnectorSchemaConfigUpdateService) SchemaChangeHandling(value string) *ConnectorSchemaConfigUpdateService {
+	csu.schemaChangeHandling = &value
+	return csu
+}
+
+func (csu *ConnectorSchemaConfigUpdateService) Schema(name string, schema *ConnectorSchemaConfigSchema) *ConnectorSchemaConfigUpdateService {
+	if csu.schemas == nil {
+		csu.schemas = make(map[string]*ConnectorSchemaConfigSchema)
+	}
+	csu.schemas[name] = schema
+	return csu
+}
+
+func (csu *ConnectorSchemaConfigUpdateService) Do(ctx context.Context) (ConnectorSchemaDetailsResponse, error) {
+	var response ConnectorSchemaDetailsResponse
+
+	if csu.connectorID == nil {
+		return response, fmt.Errorf("missing required ConnectorID")
+	}
+
+	reqBody, err := json.Marshal(csu.request())
+	if err != nil {
+		return response, err
+	}
+
+	url := fmt.Sprintf("%v/connectors/%v/schemas/", csu.c.baseURL, *csu.connectorID)
+	expectedStatus := 200
+
+	headers := csu.c.commonHeaders()
+	headers["Content-Type"] = "application/json"
+	headers["Accept"] = restAPIv2
+
+	r := request{
+		method:  "PATCH",
+		url:     url,
+		body:    reqBody,
+		queries: nil,
+		headers: headers,
+	}
+
+	respBody, respStatus, err := httpRequest(r, ctx)
+	if err != nil {
+		return response, err
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return response, err
+	}
+
+	if respStatus != expectedStatus {
+		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
+		return response, err
+	}
+
+	return response, nil
+}

--- a/connector_schema_details.go
+++ b/connector_schema_details.go
@@ -1,0 +1,70 @@
+package fivetran
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ConnectorSchemaDetailsService implements the Connector Management, Retrieve a Connector Schema Config API.
+// Ref. https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig
+type ConnectorSchemaDetailsService struct {
+	c           *Client
+	connectorID *string
+}
+
+type ConnectorSchemaDetailsResponse struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Data    struct {
+		SchemaChangeHandling string                                         `json:"schema_change_handling"`
+		Schemas              map[string]ConnectorSchemaConfigSchemaResponse `json:"schemas"`
+	} `json:"data"`
+}
+
+func (c *Client) NewConnectorSchemaDetails() *ConnectorSchemaDetailsService {
+	return &ConnectorSchemaDetailsService{c: c}
+}
+
+func (s *ConnectorSchemaDetailsService) ConnectorID(value string) *ConnectorSchemaDetailsService {
+	s.connectorID = &value
+	return s
+}
+
+func (s *ConnectorSchemaDetailsService) Do(ctx context.Context) (ConnectorSchemaDetailsResponse, error) {
+	var response ConnectorSchemaDetailsResponse
+
+	if s.connectorID == nil {
+		return response, fmt.Errorf("missing required ConnectorID")
+	}
+
+	url := fmt.Sprintf("%v/connectors/%v/schemas", s.c.baseURL, *s.connectorID)
+	expectedStatus := 200
+
+	headers := s.c.commonHeaders()
+	headers["Accept"] = restAPIv2
+
+	r := request{
+		method:  "GET",
+		url:     url,
+		body:    nil,
+		queries: nil,
+		headers: headers,
+	}
+
+	respBody, respStatus, err := httpRequest(r, ctx)
+	if err != nil {
+		return response, err
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return response, err
+	}
+
+	if respStatus != expectedStatus {
+		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
+		return response, err
+	}
+
+	return response, nil
+}

--- a/examples/connectorSchemaConfigManagement/main.go
+++ b/examples/connectorSchemaConfigManagement/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/fivetran/go-fivetran"
+)
+
+func main() {
+	apiKey := os.Getenv("FIVETRAN_APIKEY")
+	apiSecret := os.Getenv("FIVETRAN_APISECRET")
+
+	tableName := "table"
+	columnName := "column"
+	schemaName := "schema"
+	connectorId := "connectorId"
+
+	fivetran.Debug(true)
+
+	client := fivetran.New(apiKey, apiSecret)
+
+	svc := client.NewConnectorSchemaUpdateService()
+
+	table := fivetran.NewConnectorSchemaConfigTable().Enabled(true).Column(columnName, fivetran.NewConnectorSchemaConfigColumn().Enabled(true))
+	schema := fivetran.NewConnectorSchemaConfigSchema().Enabled(true).Table(tableName, table)
+
+	svc.Schema(schemaName, schema)
+
+	value, err := svc.ConnectorID(connectorId).Do(context.Background())
+	if err != nil {
+		fmt.Printf("%+v\n", value)
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%+v\n", value)
+}


### PR DESCRIPTION
Supported endpoints:
- https://fivetran.com/docs/rest-api/connectors#retrieveaconnectorschemaconfig
- https://fivetran.com/docs/rest-api/connectors#reloadaconnectorschemaconfig
- https://fivetran.com/docs/rest-api/connectors#modifyaconnectorschemaconfig