### PR TITLE
Add missing location field in destination response mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.6.5...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.6.6...HEAD)
+
+## [0.6.6](https://github.com/fivetran/go-fivetran/compare/v0.6.5...v0.6.6) - 2022-08-15
+
+## Fixed
+- `DestinationConfigResponse.Location` missing field added (field is used by BQ destination as `data_set_location` field)
 
 ## [0.6.5](https://github.com/fivetran/go-fivetran/compare/v0.6.4...v0.6.5) - 2022-08-15
 

--- a/destination_config.go
+++ b/destination_config.go
@@ -69,6 +69,7 @@ type DestinationConfigResponse struct {
 	TunnelUser           string `json:"tunnel_user"`
 	ProjectID            string `json:"project_id"`
 	DataSetLocation      string `json:"data_set_location"`
+	Location             string `json:"location"` // Big Query returns `data_set_location` as `location` in response (will be fixed with migration to API V2)
 	Bucket               string `json:"bucket"`
 	ServerHostName       string `json:"server_host_name"`
 	HTTPPath             string `json:"http_path"`

--- a/tests/destination_create_mock_test.go
+++ b/tests/destination_create_mock_test.go
@@ -32,6 +32,7 @@ const (
 	TUNNEL_USER            = "tunnel_user"
 	PROJECT_ID             = "project_id_value"
 	DATA_SET_LOCATION      = "data_Set_location_value"
+	LOCATION               = "data_Set_location_value"
 	BUCKET                 = "your-bucket"
 	SERVER_HOST_NAME       = "server.host.name"
 	HTTP_PATH              = "http.path"
@@ -120,6 +121,7 @@ func prepareResponse() string {
 					"tunnel_user":            "%v",
 					"project_id":             "%v",
 					"data_set_location":      "%v",
+					"location":               "%v",
 					"bucket":                 "%v",
 					"server_host_name":       "%v",
 					"http_path":              "%v",
@@ -157,6 +159,7 @@ func prepareResponse() string {
 		TUNNEL_USER,
 		PROJECT_ID,
 		DATA_SET_LOCATION,
+		LOCATION,
 		BUCKET,
 		SERVER_HOST_NAME,
 		HTTP_PATH,
@@ -282,4 +285,5 @@ func assertResponse(t *testing.T, response fivetran.DestinationCreateResponse) {
 	assertEqual(t, response.Data.Config.TunnelPort, TUNNEL_PORT)
 	assertEqual(t, response.Data.Config.TunnelUser, TUNNEL_USER)
 	assertEqual(t, response.Data.Config.User, USER)
+	assertEqual(t, response.Data.Config.Location, LOCATION)
 }


### PR DESCRIPTION
Added missing `location` field mapping BQ uses to return `data_set_location` in response.