### PR TITLE
fix connector response unmarshalling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.6.10...HEAD)
 
+## [0.7.1](https://github.com/fivetran/go-fivetran/compare/v0.7.0...v0.7.1) - 2022-12-14
+
+## Fixed
+- Connector response should be deserialized even if response code doesn't match expected to provide exact error that API returned.
+
 ## [0.7.0](https://github.com/fivetran/go-fivetran/compare/v0.6.10...v0.7.0) - 2022-12-14
 
 ## Added

--- a/connector_create.go
+++ b/connector_create.go
@@ -280,12 +280,12 @@ func (s *ConnectorCreateService) do(ctx context.Context, req, response any) erro
 		return err
 	}
 
-	if respStatus != expectedStatus {
-		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
+	if err := json.Unmarshal(respBody, &response); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(respBody, &response); err != nil {
+	if respStatus != expectedStatus {
+		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
 		return err
 	}
 

--- a/connector_details.go
+++ b/connector_details.go
@@ -108,12 +108,12 @@ func (s *ConnectorDetailsService) do(ctx context.Context, response any) error {
 		return err
 	}
 
-	if respStatus != expectedStatus {
-		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
+	if err := json.Unmarshal(respBody, &response); err != nil {
 		return err
 	}
 
-	if err := json.Unmarshal(respBody, &response); err != nil {
+	if respStatus != expectedStatus {
+		err := fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
 		return err
 	}
 


### PR DESCRIPTION
We definitely should unmarshal response even it response code missmatch to expected.