### PR TITLE
Handle 429 errors automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Automatic rate-limiting errors handling
+- DBT Transformations API support: create, update, delete, get details
 
 ## [0.7.3](https://github.com/fivetran/go-fivetran/compare/v0.7.2...v0.7.3)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.7.3...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v0.7.4...HEAD)
+
+## [0.7.4](https://github.com/fivetran/go-fivetran/compare/v0.7.3...v0.7.4)
+
+## Added
+- Automatic rate-limiting errors handling
 
 ## [0.7.3](https://github.com/fivetran/go-fivetran/compare/v0.7.2...v0.7.3)
 

--- a/certificate_connector_certificate_approve.go
+++ b/certificate_connector_certificate_approve.go
@@ -67,12 +67,14 @@ func (s *CertificateConnectorCertificateApproveService) Do(ctx context.Context) 
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/certificate_connector_fingerprint_approve.go
+++ b/certificate_connector_fingerprint_approve.go
@@ -67,12 +67,14 @@ func (s *CertificateConnectorFingerprintApproveService) Do(ctx context.Context) 
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/certificate_destination_certificate_approve.go
+++ b/certificate_destination_certificate_approve.go
@@ -67,12 +67,14 @@ func (s *CertificateDestinationCertificateApproveService) Do(ctx context.Context
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/certificate_destination_fingerprint_approve.go
+++ b/certificate_destination_fingerprint_approve.go
@@ -67,12 +67,14 @@ func (s *CertificateDestinationFingerprintApproveService) Do(ctx context.Context
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/client.go
+++ b/client.go
@@ -26,7 +26,7 @@ const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
 
 // WARNING: Update Agent version on each release!
-const defaultUserAgent = "Go-Fivetran/0.6.8"
+const defaultUserAgent = "Go-Fivetran/0.7.4"
 
 // New receives API Key and API Secret, and returns a new Client with the
 // default HTTP client

--- a/client.go
+++ b/client.go
@@ -14,10 +14,12 @@ type HttpClient interface {
 
 // Client holds client configuration
 type Client struct {
-	baseURL         string
-	authorization   string
-	customUserAgent string
-	httpClient      HttpClient
+	baseURL          string
+	authorization    string
+	customUserAgent  string
+	httpClient       HttpClient
+	handleRateLimits bool
+	maxRetryAttempts int
 }
 
 const defaultBaseURL = "https://api.fivetran.com/v1"
@@ -31,9 +33,11 @@ const defaultUserAgent = "Go-Fivetran/0.6.8"
 func New(apiKey, apiSecret string) *Client {
 	credentials := fmt.Sprintf("Basic %v", base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%v:%v", apiKey, apiSecret))))
 	return &Client{
-		baseURL:       defaultBaseURL,
-		authorization: credentials,
-		httpClient:    &http.Client{},
+		baseURL:          defaultBaseURL,
+		authorization:    credentials,
+		httpClient:       &http.Client{},
+		maxRetryAttempts: 2,
+		handleRateLimits: true,
 	}
 }
 
@@ -50,6 +54,16 @@ func (c *Client) CustomUserAgent(customUserAgent string) {
 // SetHttpClient sets custom HTTP client to perform requests with
 func (c *Client) SetHttpClient(httpClient HttpClient) {
 	c.httpClient = httpClient
+}
+
+// SetHandleRateLimits sets custom HTTP client to handle rate limits automatically
+func (c *Client) SetHandleRateLimits(handleRateLimits bool) {
+	c.handleRateLimits = handleRateLimits
+}
+
+// SetMaxRetryAttempts sets custom HTTP client maximum retry attempts count
+func (c *Client) SetMaxRetryAttempts(maxRetryAttempts int) {
+	c.maxRetryAttempts = maxRetryAttempts
 }
 
 func (c *Client) commonHeaders() map[string]string {

--- a/connector_create.go
+++ b/connector_create.go
@@ -267,12 +267,14 @@ func (s *ConnectorCreateService) do(ctx context.Context, req, response any) erro
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_delete.go
+++ b/connector_delete.go
@@ -40,12 +40,14 @@ func (s *ConnectorDeleteService) Do(ctx context.Context) (ConnectorDeleteRespons
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "DELETE",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "DELETE",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_details.go
+++ b/connector_details.go
@@ -94,12 +94,14 @@ func (s *ConnectorDetailsService) do(ctx context.Context, response any) error {
 	headers["Accept"] = restAPIv2
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_modify.go
+++ b/connector_modify.go
@@ -274,12 +274,14 @@ func (s *ConnectorModifyService) do(ctx context.Context, req, response any) erro
 	}
 
 	r := request{
-		method:  "PATCH",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "PATCH",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_resync_table.go
+++ b/connector_resync_table.go
@@ -58,12 +58,14 @@ func (s *ConnectorReSyncTableService) Do(ctx context.Context) (ConnectorReSyncTa
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_schema_details.go
+++ b/connector_schema_details.go
@@ -45,12 +45,14 @@ func (s *ConnectorSchemaDetailsService) Do(ctx context.Context) (ConnectorSchema
 	headers["Accept"] = restAPIv2
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_schema_reload.go
+++ b/connector_schema_reload.go
@@ -60,12 +60,14 @@ func (s *ConnectorSchemaReloadService) Do(ctx context.Context) (ConnectorSchemaD
 	headers["Accept"] = restAPIv2
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_schema_update.go
+++ b/connector_schema_update.go
@@ -77,12 +77,14 @@ func (csu *ConnectorSchemaConfigUpdateService) Do(ctx context.Context) (Connecto
 	headers["Accept"] = restAPIv2
 
 	r := request{
-		method:  "PATCH",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  csu.c.httpClient,
+		method:           "PATCH",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           csu.c.httpClient,
+		handleRateLimits: csu.c.handleRateLimits,
+		maxRetryAttempts: csu.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_setup_tests.go
+++ b/connector_setup_tests.go
@@ -105,12 +105,14 @@ func (s *ConnectorSetupTestsService) Do(ctx context.Context) (ConnectorSetupTest
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connector_sync.go
+++ b/connector_sync.go
@@ -40,18 +40,15 @@ func (s *ConnectorSyncService) Do(ctx context.Context) (ConnectorSyncResponse, e
 	headers := s.c.commonHeaders()
 	headers["Content-Type"] = "application/json"
 
-	reqBody, err := json.Marshal(s)
-	if err != nil {
-		return response, err
-	}
-
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/connectors_source_metadata.go
+++ b/connectors_source_metadata.go
@@ -61,12 +61,14 @@ func (s *ConnectorsSourceMetadataService) Do(ctx context.Context) (ConnectorsSou
 	}
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: queries,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          queries,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/dbt_project_create.go
+++ b/dbt_project_create.go
@@ -117,12 +117,14 @@ func (s *DbtProjectCreateService) Do(ctx context.Context) (DbtProjectCreateRespo
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/dbt_transformation_create.go
+++ b/dbt_transformation_create.go
@@ -93,12 +93,14 @@ func (s *DbtTransformationCreateService) Do(ctx context.Context) (DbtTransformat
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/dbt_transformation_delete.go
+++ b/dbt_transformation_delete.go
@@ -38,12 +38,14 @@ func (s *DbtTransformationDeleteService) Do(ctx context.Context) (DbtTransformat
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "DELETE",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "DELETE",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/dbt_transformation_details.go
+++ b/dbt_transformation_details.go
@@ -52,12 +52,14 @@ func (s *DbtTransformationDetailsService) Do(ctx context.Context) (DbtTransforma
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/dbt_transformation_modify.go
+++ b/dbt_transformation_modify.go
@@ -88,12 +88,14 @@ func (s *DbtTransformationModifyService) Do(ctx context.Context) (DbtTransformat
 	}
 
 	r := request{
-		method:  "PATCH",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "PATCH",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/destination_create.go
+++ b/destination_create.go
@@ -128,12 +128,14 @@ func (s *DestinationCreateService) Do(ctx context.Context) (DestinationCreateRes
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/destination_delete.go
+++ b/destination_delete.go
@@ -40,12 +40,14 @@ func (s *DestinationDeleteService) Do(ctx context.Context) (DestinationDeleteRes
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "DELETE",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "DELETE",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/destination_details.go
+++ b/destination_details.go
@@ -50,12 +50,14 @@ func (s *DestinationDetailsService) Do(ctx context.Context) (DestinationDetailsR
 	headers["Accept"] = restAPIv2
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/destination_modify.go
+++ b/destination_modify.go
@@ -123,12 +123,14 @@ func (s *DestinationModifyService) Do(ctx context.Context) (DestinationModifyRes
 	}
 
 	r := request{
-		method:  "PATCH",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "PATCH",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/destination_setup_tests.go
+++ b/destination_setup_tests.go
@@ -85,12 +85,14 @@ func (s *DestinationSetupTestsService) Do(ctx context.Context) (DestinationSetup
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/examples/connectorCreate-1/main.go
+++ b/examples/connectorCreate-1/main.go
@@ -23,7 +23,7 @@ func main() {
 		NamedRange("range1")
 
 	svc := client.NewConnectorCreate().
-		GroupID("group_id").
+		GroupID("replying_ministry").
 		Service("google_sheets").
 		Config(connConfig).
 		Paused(false).

--- a/examples/connectorCreate-1/main.go
+++ b/examples/connectorCreate-1/main.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/fivetran/go-fivetran"
 )
 
 func main() {
-	apiKey := "_moonbeam_acc_accountworthy_api_key_rbac"  //os.Getenv("FIVETRAN_APIKEY")
-	apiSecret := "_moonbeam_acc_accountworthy_api_secret" //os.Getenv("FIVETRAN_APISECRET")
+	apiKey := os.Getenv("FIVETRAN_APIKEY")
+	apiSecret := os.Getenv("FIVETRAN_APISECRET")
 	fivetran.Debug(true)
 
 	client := fivetran.New(apiKey, apiSecret)
-	client.BaseURL("http://localhost:8001/v1")
 
 	connConfig := fivetran.NewConnectorConfig().
 		Schema("google_sheets2").
@@ -23,7 +23,7 @@ func main() {
 		NamedRange("range1")
 
 	svc := client.NewConnectorCreate().
-		GroupID("_moonbeam").
+		GroupID("group_id").
 		Service("google_sheets").
 		Config(connConfig).
 		Paused(false).

--- a/examples/connectorCreate-1/main.go
+++ b/examples/connectorCreate-1/main.go
@@ -4,17 +4,17 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"os"
 
 	"github.com/fivetran/go-fivetran"
 )
 
 func main() {
-	apiKey := os.Getenv("FIVETRAN_APIKEY")
-	apiSecret := os.Getenv("FIVETRAN_APISECRET")
+	apiKey := "_moonbeam_acc_accountworthy_api_key_rbac"  //os.Getenv("FIVETRAN_APIKEY")
+	apiSecret := "_moonbeam_acc_accountworthy_api_secret" //os.Getenv("FIVETRAN_APISECRET")
 	fivetran.Debug(true)
 
 	client := fivetran.New(apiKey, apiSecret)
+	client.BaseURL("http://localhost:8001/v1")
 
 	connConfig := fivetran.NewConnectorConfig().
 		Schema("google_sheets2").
@@ -23,7 +23,7 @@ func main() {
 		NamedRange("range1")
 
 	svc := client.NewConnectorCreate().
-		GroupID("replying_ministry").
+		GroupID("_moonbeam").
 		Service("google_sheets").
 		Config(connConfig).
 		Paused(false).

--- a/group_add_user.go
+++ b/group_add_user.go
@@ -70,12 +70,14 @@ func (s *GroupAddUserService) Do(ctx context.Context) (GroupAddUserResponse, err
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_create.go
+++ b/group_create.go
@@ -57,12 +57,14 @@ func (s *GroupCreateService) Do(ctx context.Context) (GroupCreateResponse, error
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_delete.go
+++ b/group_delete.go
@@ -40,12 +40,14 @@ func (s *GroupDeleteService) Do(ctx context.Context) (groupDeleteResponse, error
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "DELETE",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "DELETE",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_details.go
+++ b/group_details.go
@@ -46,12 +46,14 @@ func (s *GroupDetailsService) Do(ctx context.Context) (GroupDetailsResponse, err
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_list_connectors.go
+++ b/group_list_connectors.go
@@ -101,12 +101,14 @@ func (s *GroupListConnectorsService) Do(ctx context.Context) (GroupListConnector
 	}
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: queries,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          queries,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_list_users.go
+++ b/group_list_users.go
@@ -77,12 +77,14 @@ func (s *GroupListUsersService) Do(ctx context.Context) (GroupListUsersResponse,
 	}
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: queries,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          queries,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_modify.go
+++ b/group_modify.go
@@ -68,12 +68,14 @@ func (s *GroupModifyService) Do(ctx context.Context) (GroupModifyResponse, error
 	}
 
 	r := request{
-		method:  "PATCH",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "PATCH",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/group_remove_user.go
+++ b/group_remove_user.go
@@ -49,12 +49,14 @@ func (s *GroupRemoveUserService) Do(ctx context.Context) (GroupRemoveUserRespons
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "DELETE",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "DELETE",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/groups_list.go
+++ b/groups_list.go
@@ -58,12 +58,14 @@ func (s *GroupsListService) Do(ctx context.Context) (GroupsListResponse, error) 
 	}
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: queries,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          queries,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/http_request.go
+++ b/http_request.go
@@ -11,10 +11,6 @@ import (
 	"time"
 )
 
-const (
-	DEBUG_BACKOFF_DELAY = 60
-)
-
 type request struct {
 	method  string
 	url     string

--- a/user_delete.go
+++ b/user_delete.go
@@ -40,12 +40,14 @@ func (s *UserDeleteService) Do(ctx context.Context) (UserDeleteResponse, error) 
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "DELETE",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "DELETE",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/user_details.go
+++ b/user_details.go
@@ -56,12 +56,14 @@ func (s *UserDetailsService) Do(ctx context.Context) (UserDetailsResponse, error
 	headers := s.c.commonHeaders()
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/user_invite.go
+++ b/user_invite.go
@@ -105,12 +105,14 @@ func (s *UserInviteService) Do(ctx context.Context) (UserInviteResponse, error) 
 	}
 
 	r := request{
-		method:  "POST",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "POST",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/user_modify.go
+++ b/user_modify.go
@@ -130,12 +130,14 @@ func (s *UserModifyService) Do(ctx context.Context) (UserModifyResponse, error) 
 	headers["Content-Type"] = "application/json"
 
 	r := request{
-		method:  "PATCH",
-		url:     url,
-		body:    reqBody,
-		queries: nil,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "PATCH",
+		url:              url,
+		body:             reqBody,
+		queries:          nil,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)

--- a/users_list.go
+++ b/users_list.go
@@ -66,12 +66,14 @@ func (s *UsersListService) Do(ctx context.Context) (UsersListResponse, error) {
 	}
 
 	r := request{
-		method:  "GET",
-		url:     url,
-		body:    nil,
-		queries: queries,
-		headers: headers,
-		client:  s.c.httpClient,
+		method:           "GET",
+		url:              url,
+		body:             nil,
+		queries:          queries,
+		headers:          headers,
+		client:           s.c.httpClient,
+		handleRateLimits: s.c.handleRateLimits,
+		maxRetryAttempts: s.c.maxRetryAttempts,
 	}
 
 	respBody, respStatus, err := r.httpRequest(ctx)


### PR DESCRIPTION
**How we handle rate limits**

Currently Fivetran Public API doesn't have any rate limits with back-off more than 1 hour. 
So we could just take "Retry-After" header and wait for retry.

**Client updates** 
Two new configuration parameters added into the client:
- `handleRateLimits bool` - flag, enables automatic handling, default value is `true`
- `maxRetryAttempts int` - max retry attempts count

We have max 1 hour back off on API side, in worst case request will hang for 1 hour. If context deadline will be exceeded - process will be interrupted with error. 