### PR TITLE
Fix dbt transformation payload and response

### DIFF
--- a/dbt_transformation_create.go
+++ b/dbt_transformation_create.go
@@ -34,7 +34,6 @@ type DbtTransformationCreateResponse struct {
 		DbtModelId      string                            `json:"dbt_model_id"`
 		NextRun         string                            `json:"next_run"`
 		CreatedAt       string                            `json:"created_at"`
-		RunTests        string                            `json:"run_tests"`
 		ModelIds        []string                          `json:"model_ids"`
 		ConnectorIds    []string                          `json:"connector_ids"`
 	} `json:"data"`

--- a/dbt_transformation_create_test.go
+++ b/dbt_transformation_create_test.go
@@ -40,7 +40,6 @@ func TestNewDbtTransformationCreateE2E(t *testing.T) {
 	AssertEqual(t, created.Data.DbtModelId, "")
 	AssertEqual(t, created.Data.NextRun, "")
 	AssertEqual(t, created.Data.CreatedAt, "")
-	AssertEqual(t, created.Data.RunTests, "")
 	AssertEqual(t, created.Data.ModelIds, "")
 	AssertEqual(t, created.Data.ConnectorIds, "")
 

--- a/dbt_transformation_details.go
+++ b/dbt_transformation_details.go
@@ -24,7 +24,6 @@ type DbtTransformationDetailsResponse struct {
 		DbtModelId      string                            `json:"dbt_model_id"`
 		NextRun         string                            `json:"next_run"`
 		CreatedAt       string                            `json:"created_at"`
-		RunTests        string                            `json:"run_tests"`
 		ModelIds        []string                          `json:"model_ids"`
 		ConnectorIds    []string                          `json:"connector_ids"`
 	} `json:"data"`

--- a/dbt_transformation_details_test.go
+++ b/dbt_transformation_details_test.go
@@ -32,7 +32,6 @@ func TestNewDbtTransformationDetailsE2E(t *testing.T) {
 	AssertEqual(t, details.Data.DbtModelId, "")
 	AssertEqual(t, details.Data.NextRun, "")
 	AssertEqual(t, details.Data.CreatedAt, "")
-	AssertEqual(t, details.Data.RunTests, "")
 	AssertEqual(t, details.Data.ModelIds, "")
 	AssertEqual(t, details.Data.ConnectorIds, "")
 }

--- a/dbt_transformation_modify.go
+++ b/dbt_transformation_modify.go
@@ -31,7 +31,6 @@ type DbtTransformationModifyResponse struct {
 		DbtModelId      string                            `json:"dbt_model_id"`
 		NextRun         string                            `json:"next_run"`
 		CreatedAt       string                            `json:"created_at"`
-		RunTests        string                            `json:"run_tests"`
 		ModelIds        []string                          `json:"model_ids"`
 		ConnectorIds    []string                          `json:"connector_ids"`
 	} `json:"data"`

--- a/dbt_transformation_modify_test.go
+++ b/dbt_transformation_modify_test.go
@@ -40,7 +40,6 @@ func TestNewDbtTransformationModifyE2E(t *testing.T) {
 	AssertEqual(t, details.Data.DbtModelId, "")
 	AssertEqual(t, details.Data.NextRun, "")
 	AssertEqual(t, details.Data.CreatedAt, "")
-	AssertEqual(t, details.Data.RunTests, "")
 	AssertEqual(t, details.Data.ModelIds, "")
 	AssertEqual(t, details.Data.ConnectorIds, "")
 }

--- a/dbt_transformation_schedule.go
+++ b/dbt_transformation_schedule.go
@@ -17,7 +17,7 @@ type dbtTransformationScheduleRequest struct {
 type dbtTransformationScheduleResponse struct {
 	ScheduleType string   `json:"schedule_type"`
 	DaysOfWeek   []string `json:"days_of_week"`
-	Interval     string   `json:"interval"`
+	Interval     int      `json:"interval"`
 	TimeOfDay    string   `json:"time_of_day"`
 }
 

--- a/tests/dbt_transformation_create_mock_test.go
+++ b/tests/dbt_transformation_create_mock_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/fivetran/go-fivetran"
@@ -85,7 +84,7 @@ func prepareDbtTransformationResponse() string {
 					"days_of_week": [
 						"%v"
 					],
-					"interval": "%v",
+					"interval": %v,
 					"time_of_day": "%v"
 				},
 				"last_run": "%v",
@@ -94,7 +93,7 @@ func prepareDbtTransformationResponse() string {
 				"dbt_model_id": "%v",
 				"next_run": "%v",
 				"created_at": "%v",
-				"run_tests": "%v",
+				"run_tests": %v,
 				"model_ids": [
 					"%v"
 				],
@@ -153,12 +152,11 @@ func assertDbtTransformationResponse(t *testing.T, response fivetran.DbtTransfor
 	assertEqual(t, response.Data.DbtModelId, DBT_MODEL_ID)
 	assertEqual(t, response.Data.NextRun, NEXT_RUN)
 	assertEqual(t, response.Data.CreatedAt, CREATED_AT)
-	assertEqual(t, response.Data.RunTests, boolToStr(RUN_TESTS))
 	assertEqual(t, response.Data.ModelIds[0], MODEL_ID)
 	assertEqual(t, response.Data.ConnectorIds[0], CONNECTOR_ID)
 
 	assertEqual(t, response.Data.Schedule.ScheduleType, SCHEDULE_TYPE)
 	assertEqual(t, response.Data.Schedule.DaysOfWeek, daysOfWeek)
-	assertEqual(t, response.Data.Schedule.Interval, strconv.Itoa(INTERVAL))
+	assertEqual(t, response.Data.Schedule.Interval, INTERVAL)
 	assertEqual(t, response.Data.Schedule.TimeOfDay, TIME_OF_DAY)
 }

--- a/tests/dbt_transformation_details_mock_test.go
+++ b/tests/dbt_transformation_details_mock_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/fivetran/go-fivetran"
@@ -52,7 +51,7 @@ func prepareDbtTransformationDetailsResponse() string {
 					"days_of_week": [
 						"%v"
 					],
-					"interval": "%v",
+					"interval": %v,
 					"time_of_day": "%v"
 				},
 				"last_run": "%v",
@@ -61,7 +60,7 @@ func prepareDbtTransformationDetailsResponse() string {
 				"dbt_model_id": "%v",
 				"next_run": "%v",
 				"created_at": "%v",
-				"run_tests": "%v",
+				"run_tests": %v,
 				"model_ids": [
 					"%v"
 				],
@@ -98,12 +97,11 @@ func assertDbtTransformationDetailsResponse(t *testing.T, response fivetran.DbtT
 	assertEqual(t, response.Data.DbtModelId, DBT_MODEL_ID)
 	assertEqual(t, response.Data.NextRun, NEXT_RUN)
 	assertEqual(t, response.Data.CreatedAt, CREATED_AT)
-	assertEqual(t, response.Data.RunTests, boolToStr(RUN_TESTS))
 	assertEqual(t, response.Data.ModelIds[0], MODEL_ID)
 	assertEqual(t, response.Data.ConnectorIds[0], CONNECTOR_ID)
 
 	assertEqual(t, response.Data.Schedule.ScheduleType, SCHEDULE_TYPE)
 	assertEqual(t, response.Data.Schedule.DaysOfWeek, daysOfWeek)
-	assertEqual(t, response.Data.Schedule.Interval, strconv.Itoa(INTERVAL))
+	assertEqual(t, response.Data.Schedule.Interval, INTERVAL)
 	assertEqual(t, response.Data.Schedule.TimeOfDay, TIME_OF_DAY)
 }

--- a/tests/dbt_transformation_modify_mock_test.go
+++ b/tests/dbt_transformation_modify_mock_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"strconv"
 	"testing"
 
 	"github.com/fivetran/go-fivetran"
@@ -73,7 +72,7 @@ func prepareDbtTransformationModifyResponse() string {
 					"days_of_week": [
 						"%v"
 					],
-					"interval": "%v",
+					"interval": %v,
 					"time_of_day": "%v"
 				},
 				"last_run": "%v",
@@ -82,7 +81,7 @@ func prepareDbtTransformationModifyResponse() string {
 				"dbt_model_id": "%v",
 				"next_run": "%v",
 				"created_at": "%v",
-				"run_tests": "%v",
+				"run_tests": %v,
 				"model_ids": [
 					"%v"
 				],
@@ -121,12 +120,11 @@ func assertDbtTransformationModifyResponse(t *testing.T, response fivetran.DbtTr
 	assertEqual(t, response.Data.DbtModelId, DBT_MODEL_ID)
 	assertEqual(t, response.Data.NextRun, NEXT_RUN)
 	assertEqual(t, response.Data.CreatedAt, CREATED_AT)
-	assertEqual(t, response.Data.RunTests, boolToStr(NEW_RUN_TESTS))
 	assertEqual(t, response.Data.ModelIds[0], MODEL_ID)
 	assertEqual(t, response.Data.ConnectorIds[0], CONNECTOR_ID)
 
 	assertEqual(t, response.Data.Schedule.ScheduleType, NEW_SCHEDULE_TYPE)
 	assertEqual(t, response.Data.Schedule.DaysOfWeek, newDaysOfWeek)
-	assertEqual(t, response.Data.Schedule.Interval, strconv.Itoa(NEW_INTERVAL))
+	assertEqual(t, response.Data.Schedule.Interval, NEW_INTERVAL)
 	assertEqual(t, response.Data.Schedule.TimeOfDay, NEW_TIME_OF_DAY)
 }


### PR DESCRIPTION
- We don't need to have `run_tests` flag in response - it's useless.
- `schedule.interval` is a field of integer type in response (same as in request)