### PR TITLE
Fix `DestinationConfigResponse` struct format.

### DIFF
--- a/destinations/destination_config.go
+++ b/destinations/destination_config.go
@@ -112,7 +112,7 @@ type DestinationConfigResponse struct {
     ClusterId             string `json:"cluster_id"`
     ClusterRegion         string `json:"cluster_region"`
     Role                  string `json:"role"`
-    IsPrivateKeyEncrypted string `json:"is_private_key_encrypted"`
+    IsPrivateKeyEncrypted *bool  `json:"is_private_key_encrypted,omitempty"`
     Passphrase            string `json:"passphrase"`
     Catalog               string `json:"catalog"`
     FivetranRoleArn       string `json:"fivetran_role_arn"`


### PR DESCRIPTION
w/r/t `DestinationConfigResponse`:

`IsPrivateKeyEncrypted` comes back as a `bool`, not a `string`, and thus fails unmarshalling, as written.

**See:**
```
json: cannot unmarshal bool into Go struct field DestinationConfigResponse.data.config.is_private_key_encrypted of type string;
```

We — Runway.com — are depending on the fork this PR is derived from, until this is fixed.

---

_I've read your `CONTRIBUTING.md` and assume one-liners are probably still welcome._