### PR TITLE
Feature/quickstart rename configurable variables v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.0...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.1...HEAD)
+
+## [1.3.1](https://github.com/fivetran/go-fivetran/compare/v1.3.0...v1.3.1)
+
+## Changed
+- Renamed `ConfigurableVarDefinition` to `ConfigurableVariableDefinition` to align with the API field name (`configurable_variables`).
+- Renamed `ConfigurableVars` field on `quickstartPackageResponseBase` to `ConfigurableVariables`.
 
 ## [1.3.0](https://github.com/fivetran/go-fivetran/compare/v1.2.9...v1.3.0)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.3.1](https://github.com/fivetran/go-fivetran/compare/v1.3.0...v1.3.1)
 
+## Added
+- `ConfigurableVariables` field (`map[string]interface{}`) to `transformationConfigResponse`, deserializing `configurable_variables` from `GET /transformations/{id}` and `GET /transformations` responses.
+- `ConfigurableVariables` field (`*map[string]interface{}`) to `transformationConfigRequest`, serializing `configurable_variables` in `POST /transformations` and `PATCH /transformations/{id}` requests.
+- `configurableVariables` field to `TransformationConfig` builder struct with `ConfigurableVariables(value map[string]interface{})` builder method.
+
 ## Changed
 - Renamed `ConfigurableVarDefinition` to `ConfigurableVariableDefinition` to align with the API field name (`configurable_variables`).
 - Renamed `ConfigurableVars` field on `quickstartPackageResponseBase` to `ConfigurableVariables`.

--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
 
 // WARNING: Update Agent version on each release!
-const defaultUserAgent = "Go-Fivetran/1.3.1"
+const defaultUserAgent = "Go-Fivetran/1.3.0"
 
 // New receives API Key and API Secret, and returns a new Client with the
 // default HTTP client

--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
 
 // WARNING: Update Agent version on each release!
-const defaultUserAgent = "Go-Fivetran/1.3.0"
+const defaultUserAgent = "Go-Fivetran/1.3.1"
 
 // New receives API Key and API Secret, and returns a new Client with the
 // default HTTP client

--- a/transformations/common_types.go
+++ b/transformations/common_types.go
@@ -167,9 +167,10 @@ type TransformationConfig struct {
 	name      *string
 	steps     *[]TransformationStep
 	/* QUICKSTART */
-	packageName    *string
-	connectionIds  *[]string
-	excludedModels *[]string
+	packageName           *string
+	connectionIds         *[]string
+	excludedModels        *[]string
+	configurableVariables *map[string]interface{}
 }
 
 type transformationConfigRequest struct {
@@ -178,9 +179,10 @@ type transformationConfigRequest struct {
 	Name      *string               `json:"name,omitempty"`
 	Steps     *[]TransformationStep `json:"steps,omitempty"`
 	/* QUICKSTART */
-	PackageName    *string   `json:"package_name,omitempty"`
-	ConnectionIds  *[]string `json:"connection_ids,omitempty"`
-	ExcludedModels *[]string `json:"excluded_models,omitempty"`
+	PackageName           *string                 `json:"package_name,omitempty"`
+	ConnectionIds         *[]string               `json:"connection_ids,omitempty"`
+	ExcludedModels        *[]string               `json:"excluded_models,omitempty"`
+	ConfigurableVariables *map[string]interface{} `json:"configurable_variables,omitempty"`
 }
 
 type TransformationStep struct {
@@ -194,10 +196,11 @@ type transformationConfigResponse struct {
 	Name      string               `json:"name,omitempty"`
 	Steps     []TransformationStep `json:"steps,omitempty"`
 	/* QUICKSTART */
-	PackageName      string   `json:"package_name,omitempty"`
-	ConnectionIds    []string `json:"connection_ids,omitempty"`
-	ExcludedModels   []string `json:"excluded_models,omitempty"`
-	UpgradeAvailable bool     `json:"upgrade_available,omitempty"`
+	PackageName           string                 `json:"package_name,omitempty"`
+	ConnectionIds         []string               `json:"connection_ids,omitempty"`
+	ExcludedModels        []string               `json:"excluded_models,omitempty"`
+	UpgradeAvailable      bool                   `json:"upgrade_available,omitempty"`
+	ConfigurableVariables map[string]interface{} `json:"configurable_variables,omitempty"`
 }
 
 type transformationCreateRequest struct {

--- a/transformations/common_types.go
+++ b/transformations/common_types.go
@@ -297,7 +297,7 @@ type ConfigurableVariableDefinition struct {
 	AllowedValues []string `json:"allowed_values,omitempty"`
 }
 
-type quickstartPackageResponseBase struct {
+type quickstartPackageMetadataResponseBase struct {
 	Id                    string                                    `json:"id,omitempty"`
 	Name                  string                                    `json:"name,omitempty"`
 	Version               string                                    `json:"version,omitempty"`
@@ -306,17 +306,17 @@ type quickstartPackageResponseBase struct {
 	ConfigurableVariables map[string]ConfigurableVariableDefinition `json:"configurable_variables,omitempty"`
 }
 
-type QuickstartPackageResponse struct {
+type QuickstartPackageMetadataResponse struct {
 	common.CommonResponse
 	Data struct {
-		quickstartPackageResponseBase
+		quickstartPackageMetadataResponseBase
 	} `json:"data"`
 }
 
-type QuickstartPackagesListResponse struct {
+type QuickstartPackagesMetadataListResponse struct {
 	common.CommonResponse
 	Data struct {
-		Items      []quickstartPackageResponseBase `json:"items"`
+		Items      []quickstartPackageMetadataResponseBase `json:"items"`
 		NextCursor string                          `json:"next_cursor"`
 	} `json:"data"`
 }

--- a/transformations/common_types.go
+++ b/transformations/common_types.go
@@ -288,19 +288,19 @@ type transformationCustomUpdateRequest struct {
 
 /* Quickstart metadata details*/
 
-type ConfigurableVarDefinition struct {
+type ConfigurableVariableDefinition struct {
 	Type          string   `json:"type,omitempty"`
 	Description   string   `json:"description,omitempty"`
 	AllowedValues []string `json:"allowed_values,omitempty"`
 }
 
 type quickstartPackageResponseBase struct {
-	Id               string                               `json:"id,omitempty"`
-	Name             string                               `json:"name,omitempty"`
-	Version          string                               `json:"version,omitempty"`
-	ConnectorTypes   []string                             `json:"connector_types,omitempty"`
-	OutputModelNames []string                             `json:"output_model_names,omitempty"`
-	ConfigurableVars map[string]ConfigurableVarDefinition `json:"configurable_variables,omitempty"`
+	Id                    string                                    `json:"id,omitempty"`
+	Name                  string                                    `json:"name,omitempty"`
+	Version               string                                    `json:"version,omitempty"`
+	ConnectorTypes        []string                                  `json:"connector_types,omitempty"`
+	OutputModelNames      []string                                  `json:"output_model_names,omitempty"`
+	ConfigurableVariables map[string]ConfigurableVariableDefinition `json:"configurable_variables,omitempty"`
 }
 
 type QuickstartPackageResponse struct {

--- a/transformations/quickstart_package_metadata_details.go
+++ b/transformations/quickstart_package_metadata_details.go
@@ -17,8 +17,8 @@ func (s *QuickstartPackageDetailsService) PackageDefinitionId(value string) *Qui
 	return s
 }
 
-func (s *QuickstartPackageDetailsService) Do(ctx context.Context) (QuickstartPackageResponse, error) {
-	var response QuickstartPackageResponse
+func (s *QuickstartPackageDetailsService) Do(ctx context.Context) (QuickstartPackageMetadataResponse, error) {
+	var response QuickstartPackageMetadataResponse
 
 	if s.packageDefinitionId == nil {
 		return response, fmt.Errorf("missing required packageDefinitionId")

--- a/transformations/quickstart_package_metadata_details_test.go
+++ b/transformations/quickstart_package_metadata_details_test.go
@@ -62,7 +62,7 @@ func prepareQuickstartPackageDetailsResponse() string {
 }`
 }
 
-func assertQuickstartPackageDetailsResponse(t *testing.T, response transformations.QuickstartPackageResponse) {
+func assertQuickstartPackageDetailsResponse(t *testing.T, response transformations.QuickstartPackageMetadataResponse) {
     testutils.AssertEqual(t, response.Code, "Success")
     testutils.AssertNotEmpty(t, response.Message)
     testutils.AssertEqual(t, response.Data.Id, "package_definition_id")

--- a/transformations/quickstart_package_metadata_details_test.go
+++ b/transformations/quickstart_package_metadata_details_test.go
@@ -70,8 +70,8 @@ func assertQuickstartPackageDetailsResponse(t *testing.T, response transformatio
     testutils.AssertEqual(t, response.Data.Version, "version")
     testutils.AssertEqual(t, response.Data.ConnectorTypes[0], "string")
     testutils.AssertEqual(t, response.Data.OutputModelNames[0], "string")
-    testutils.AssertEqual(t, response.Data.ConfigurableVars["start_date"].Type, "DATE")
-    testutils.AssertEqual(t, response.Data.ConfigurableVars["start_date"].Description, "The start date for historical data")
-    testutils.AssertEqual(t, response.Data.ConfigurableVars["start_date"].AllowedValues[0], "2020-01-01")
-    testutils.AssertEqual(t, response.Data.ConfigurableVars["start_date"].AllowedValues[1], "2021-01-01")
+    testutils.AssertEqual(t, response.Data.ConfigurableVariables["start_date"].Type, "DATE")
+    testutils.AssertEqual(t, response.Data.ConfigurableVariables["start_date"].Description, "The start date for historical data")
+    testutils.AssertEqual(t, response.Data.ConfigurableVariables["start_date"].AllowedValues[0], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.ConfigurableVariables["start_date"].AllowedValues[1], "2021-01-01")
 }

--- a/transformations/quickstart_package_metadata_list.go
+++ b/transformations/quickstart_package_metadata_list.go
@@ -23,8 +23,8 @@ func (s *QuickstartPackagesListService) Cursor(value string) *QuickstartPackages
 	return s
 }
 
-func (s *QuickstartPackagesListService) Do(ctx context.Context) (QuickstartPackagesListResponse, error) {
-	var response QuickstartPackagesListResponse
+func (s *QuickstartPackagesListService) Do(ctx context.Context) (QuickstartPackagesMetadataListResponse, error) {
+	var response QuickstartPackagesMetadataListResponse
 	var queries map[string]string = nil
 	if s.cursor != nil || s.limit != nil {
 		queries = make(map[string]string)

--- a/transformations/quickstart_package_metadata_list_test.go
+++ b/transformations/quickstart_package_metadata_list_test.go
@@ -79,9 +79,9 @@ func assertQuickstartPackagesListResponse(t *testing.T, response transformations
     testutils.AssertEqual(t, response.Data.Items[0].Version, "version")
     testutils.AssertEqual(t, response.Data.Items[0].ConnectorTypes[0], "string")
     testutils.AssertEqual(t, response.Data.Items[0].OutputModelNames[0], "string")
-    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVars["start_date"].Type, "DATE")
-    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVars["start_date"].Description, "The start date for historical data")
-    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVars["start_date"].AllowedValues[0], "2020-01-01")
-    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVars["start_date"].AllowedValues[1], "2021-01-01")
+    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVariables["start_date"].Type, "DATE")
+    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVariables["start_date"].Description, "The start date for historical data")
+    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVariables["start_date"].AllowedValues[0], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.Items[0].ConfigurableVariables["start_date"].AllowedValues[1], "2021-01-01")
     testutils.AssertEqual(t, response.Data.NextCursor, "cursor_value")
 }

--- a/transformations/quickstart_package_metadata_list_test.go
+++ b/transformations/quickstart_package_metadata_list_test.go
@@ -19,7 +19,7 @@ func TestQuickstartPackagesListServiceDo(t *testing.T) {
 	ftClient, mockClient := testutils.CreateTestClient()
 	handler := mockClient.When(http.MethodGet, "/v1/transformations/package-metadata").
 		ThenCall(func(req *http.Request) (*http.Response, error) {
-			response := mock.NewResponse(req, http.StatusOK, prepareQuickstartPackagesListResponse())
+			response := mock.NewResponse(req, http.StatusOK, prepareQuickstartPackagesMetadataListResponse())
 			return response, nil
 		})
 
@@ -38,10 +38,10 @@ func TestQuickstartPackagesListServiceDo(t *testing.T) {
 	testutils.AssertEqual(t, len(interactions), 1)
 	testutils.AssertEqual(t, interactions[0].Handler, handler)
 	testutils.AssertEqual(t, handler.Interactions, 1)
-	assertQuickstartPackagesListResponse(t, response)
+	assertQuickstartPackagesMetadataListResponse(t, response)
 }
 
-func prepareQuickstartPackagesListResponse() string {
+func prepareQuickstartPackagesMetadataListResponse() string {
 	return `{
   "code": "Success",
   "message": "Operation performed.",
@@ -71,7 +71,7 @@ func prepareQuickstartPackagesListResponse() string {
 }`
 }
 
-func assertQuickstartPackagesListResponse(t *testing.T, response transformations.QuickstartPackagesListResponse) {
+func assertQuickstartPackagesMetadataListResponse(t *testing.T, response transformations.QuickstartPackagesMetadataListResponse) {
     testutils.AssertEqual(t, response.Code, "Success")
     testutils.AssertNotEmpty(t, response.Message)
     testutils.AssertEqual(t, response.Data.Items[0].Id, "package_definition_id")

--- a/transformations/transformation_config.go
+++ b/transformations/transformation_config.go
@@ -4,13 +4,14 @@ import "github.com/fivetran/go-fivetran/utils"
 
 func (elc *TransformationConfig) Request() *transformationConfigRequest {
 	return &transformationConfigRequest{
-		ProjectId:  	elc.projectId,
-		Name:  			elc.name,
-		Steps: 			elc.steps,
-		PackageName:    elc.packageName,
-    	ConnectionIds:  elc.connectionIds,
-    	ExcludedModels: elc.excludedModels,
-    }
+		ProjectId:             elc.projectId,
+		Name:                  elc.name,
+		Steps:                 elc.steps,
+		PackageName:           elc.packageName,
+		ConnectionIds:         elc.connectionIds,
+		ExcludedModels:        elc.excludedModels,
+		ConfigurableVariables: elc.configurableVariables,
+	}
 }
 
 func (elc *TransformationConfig) Merge(customConfig *map[string]interface{}) (*map[string]interface{}, error) {
@@ -48,5 +49,10 @@ func (elc *TransformationConfig) ConnectionIds(value []string) *TransformationCo
 
 func (elc *TransformationConfig) ExcludedModels(value []string) *TransformationConfig {
 	elc.excludedModels = &value
+	return elc
+}
+
+func (elc *TransformationConfig) ConfigurableVariables(value map[string]interface{}) *TransformationConfig {
+	elc.configurableVariables = &value
 	return elc
 }

--- a/transformations/transformation_create_test.go
+++ b/transformations/transformation_create_test.go
@@ -164,6 +164,10 @@ func prepareTransformationResponse() string {
         "string"
       ],
       "upgrade_available": true,
+      "configurable_variables": {
+        "start_date": "2020-01-01",
+        "use_full_refresh": true
+      },
       "fake_field": "unmapped-value"
     }
   }
@@ -178,6 +182,7 @@ func prepareTransformationConfig() *transformations.TransformationConfig {
   config.PackageName("string")
   config.ConnectionIds([]string{"string"})
   config.ExcludedModels([]string{"string"})
+  config.ConfigurableVariables(map[string]interface{}{"start_date": "2020-01-01", "use_full_refresh": true})
 
   return config
 }
@@ -233,6 +238,7 @@ func assertTransformationFullRequest(t *testing.T, request map[string]interface{
     testutils.AssertKey(t, "package_name", config, "string")
     testutils.AssertHasKey(t, config, "connection_ids")
     testutils.AssertHasKey(t, config, "excluded_models")
+    testutils.AssertHasKey(t, config, "configurable_variables")
 }
 
 func assertTransformationCustomRequest(t *testing.T, request map[string]interface{}) {
@@ -271,6 +277,7 @@ func assertTransformationCustomMergedRequest(t *testing.T, request map[string]in
     testutils.AssertKey(t, "package_name", config, "string")
     testutils.AssertHasKey(t, config, "connection_ids")
     testutils.AssertHasKey(t, config, "excluded_models")
+    testutils.AssertHasKey(t, config, "configurable_variables")
     testutils.AssertKey(t, "fake_field", config, "unmapped-value")
 }
 
@@ -301,6 +308,8 @@ func assertTransformationResponse(t *testing.T, response transformations.Transfo
     testutils.AssertEqual(t, response.Data.TransformationConfig.ConnectionIds[0], "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.ExcludedModels[0], "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.UpgradeAvailable, true)
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["start_date"], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["use_full_refresh"], true)
 }
 
 func assertTransformationCustomResponse(t *testing.T, response transformations.TransformationCustomResponse) {
@@ -361,6 +370,8 @@ func assertTransformationCustomMergedResponse(t *testing.T, response transformat
     testutils.AssertEqual(t, response.Data.TransformationConfig.ConnectionIds[0], "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.ExcludedModels[0], "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.UpgradeAvailable, true)
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["start_date"], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["use_full_refresh"], true)
 
     testutils.AssertKey(t, "fake_field", response.Data.TransformationConfigCustom, "unmapped-value")
 }

--- a/transformations/transformation_details_test.go
+++ b/transformations/transformation_details_test.go
@@ -85,7 +85,11 @@ func prepareTransformationDetailsResponse() string {
           "excluded_models": [
             "string"
           ],
-          "upgrade_available": true
+          "upgrade_available": true,
+          "configurable_variables": {
+            "start_date": "2020-01-01",
+            "use_full_refresh": true
+          }
     }
   }
 }`
@@ -119,4 +123,6 @@ func assertTransformationDetailsResponse(t *testing.T, response transformations.
     testutils.AssertEqual(t, response.Data.TransformationConfig.ConnectionIds[0], "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.ExcludedModels[0], "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.UpgradeAvailable, true)
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["start_date"], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["use_full_refresh"], true)
 }

--- a/transformations/transformation_update_test.go
+++ b/transformations/transformation_update_test.go
@@ -156,6 +156,10 @@ func prepareTransformationUpdateResponse() string {
           "command": "string"
         }
       ],
+      "configurable_variables": {
+        "start_date": "2020-01-01",
+        "use_full_refresh": true
+      },
       "fake_field": "unmapped-value"
     }
   }
@@ -167,6 +171,7 @@ func prepareTransformationUpdateConfig() *transformations.TransformationConfig {
   config.ProjectId("string")
   config.Name("string")
   config.Steps([]transformations.TransformationStep{{Name: "string", Command: "string"}})
+  config.ConfigurableVariables(map[string]interface{}{"start_date": "2020-01-01", "use_full_refresh": true})
 
   return config
 }
@@ -218,6 +223,7 @@ func assertTransformationFullUpdateRequest(t *testing.T, request map[string]inte
     testutils.AssertKey(t, "project_id", config, "string")
     testutils.AssertKey(t, "name", config, "string")
     testutils.AssertHasKey(t, config, "steps")
+    testutils.AssertHasKey(t, config, "configurable_variables")
 }
 
 func assertTransformationCustomUpdateRequest(t *testing.T, request map[string]interface{}) {
@@ -251,6 +257,7 @@ func assertTransformationCustomMergedUpdateRequest(t *testing.T, request map[str
     testutils.AssertKey(t, "project_id", config, "string")
     testutils.AssertKey(t, "name", config, "string")
     testutils.AssertHasKey(t, config, "steps")
+    testutils.AssertHasKey(t, config, "configurable_variables")
     testutils.AssertKey(t, "fake_field", config, "unmapped-value")
 }
 
@@ -278,6 +285,8 @@ func assertTransformationUpdateResponse(t *testing.T, response transformations.T
     testutils.AssertEqual(t, response.Data.TransformationConfig.Name, "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.Steps[0].Name, "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.Steps[0].Command, "string")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["start_date"], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["use_full_refresh"], true)
 }
 
 func assertTransformationCustomUpdateResponse(t *testing.T, response transformations.TransformationCustomResponse) {
@@ -330,6 +339,8 @@ func assertTransformationCustomMergedUpdateResponse(t *testing.T, response trans
     testutils.AssertEqual(t, response.Data.TransformationConfig.Name, "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.Steps[0].Name, "string")
     testutils.AssertEqual(t, response.Data.TransformationConfig.Steps[0].Command, "string")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["start_date"], "2020-01-01")
+    testutils.AssertEqual(t, response.Data.TransformationConfig.ConfigurableVariables["use_full_refresh"], true)
 
     testutils.AssertKey(t, "fake_field", response.Data.TransformationConfigCustom, "unmapped-value")
 }


### PR DESCRIPTION
 - Renamed ConfigurableVarDefinition → ConfigurableVariableDefinition and ConfigurableVars → ConfigurableVariables on quickstartPackageResponseBase to align with the API field name
  - Added ConfigurableVariables map[string]interface{} to transformationConfigResponse to deserialize configurable_variables from GET transformation responses
  - Added ConfigurableVariables *map[string]interface{} to transformationConfigRequest to serialize configurable_variables in POST/PATCH transformation requests
  - Added configurableVariables field to TransformationConfig builder struct with ConfigurableVariables() builder method
  - Updated transformation details, create, and update tests with configurable_variables mock data and assertions
