### PR TITLE
Add connector SDK package CRUD client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.1...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.2...HEAD)
+
+## [1.3.2](https://github.com/fivetran/go-fivetran/compare/v1.3.1...v1.3.2)
+
+## Added
+- `connector_sdk` module with full Connector SDK package CRUD support: Create, Get, List, Update, Delete.
+- `ConnectorSdkPackageData` type with `FileSha256Hash` field for package integrity verification.
+- `DoMultipart()` method on `HttpService` for `multipart/form-data` file uploads (used by package Create and Update).
+- Client methods: `NewConnectorSdkPackageCreate()`, `NewConnectorSdkPackageDetails()`, `NewConnectorSdkPackageUpdate()`, `NewConnectorSdkPackageDelete()`, `NewConnectorSdkPackageList()`.
 
 ## [1.3.1](https://github.com/fivetran/go-fivetran/compare/v1.3.0...v1.3.1)
 

--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"github.com/fivetran/go-fivetran/certificates"
 	connectcard "github.com/fivetran/go-fivetran/connect_card"
 	"github.com/fivetran/go-fivetran/connections"
+	connectorsdk "github.com/fivetran/go-fivetran/connector_sdk"
 	"github.com/fivetran/go-fivetran/destinations"
 	externallogging "github.com/fivetran/go-fivetran/external_logging"
 	"github.com/fivetran/go-fivetran/fingerprints"
@@ -246,6 +247,27 @@ func (c *Client) NewGroupSshPublicKey() *groups.GroupSshKeyService {
 
 func (c *Client) NewGroupServiceAccount() *groups.GroupServiceAccountService {
 	return &groups.GroupServiceAccountService{HttpService: c.NewHttpService()}
+}
+
+/* Connector SDK Packages */
+func (c *Client) NewConnectorSdkPackageCreate() *connectorsdk.ConnectorSdkPackageCreateService {
+	return &connectorsdk.ConnectorSdkPackageCreateService{HttpService: c.NewHttpService()}
+}
+
+func (c *Client) NewConnectorSdkPackageDetails() *connectorsdk.ConnectorSdkPackageDetailsService {
+	return &connectorsdk.ConnectorSdkPackageDetailsService{HttpService: c.NewHttpService()}
+}
+
+func (c *Client) NewConnectorSdkPackageUpdate() *connectorsdk.ConnectorSdkPackageUpdateService {
+	return &connectorsdk.ConnectorSdkPackageUpdateService{HttpService: c.NewHttpService()}
+}
+
+func (c *Client) NewConnectorSdkPackageDelete() *connectorsdk.ConnectorSdkPackageDeleteService {
+	return &connectorsdk.ConnectorSdkPackageDeleteService{HttpService: c.NewHttpService()}
+}
+
+func (c *Client) NewConnectorSdkPackageList() *connectorsdk.ConnectorSdkPackageListService {
+	return &connectorsdk.ConnectorSdkPackageListService{HttpService: c.NewHttpService()}
 }
 
 /* External Logging */

--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
 
 // WARNING: Update Agent version on each release!
-const defaultUserAgent = "Go-Fivetran/1.3.1"
+const defaultUserAgent = "Go-Fivetran/1.3.2"
 
 // New receives API Key and API Secret, and returns a new Client with the
 // default HTTP client

--- a/connector_sdk/common_types.go
+++ b/connector_sdk/common_types.go
@@ -1,0 +1,30 @@
+package connectorsdk
+
+import (
+	"time"
+
+	"github.com/fivetran/go-fivetran/common"
+)
+
+type ConnectorSdkPackageData struct {
+	ID             string    `json:"id"`
+	ConnectionID   string    `json:"connection_id"`
+	CreatedBy      string    `json:"created_by"`
+	LastUpdatedBy  string    `json:"last_updated_by"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
+	FileSha256Hash string    `json:"file_sha256_hash"`
+}
+
+type ConnectorSdkPackageResponse struct {
+	common.CommonResponse
+	Data ConnectorSdkPackageData `json:"data"`
+}
+
+type ConnectorSdkPackagesListResponse struct {
+	common.CommonResponse
+	Data struct {
+		Items      []ConnectorSdkPackageData `json:"items"`
+		NextCursor string                    `json:"next_cursor"`
+	} `json:"data"`
+}

--- a/connector_sdk/connector_sdk_package_create.go
+++ b/connector_sdk/connector_sdk_package_create.go
@@ -1,0 +1,40 @@
+package connectorsdk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	httputils "github.com/fivetran/go-fivetran/http_utils"
+)
+
+type ConnectorSdkPackageCreateService struct {
+	httputils.HttpService
+	fileContent io.Reader
+	fileName    *string
+}
+
+func (s *ConnectorSdkPackageCreateService) FileContent(value io.Reader) *ConnectorSdkPackageCreateService {
+	s.fileContent = value
+	return s
+}
+
+func (s *ConnectorSdkPackageCreateService) FileName(value string) *ConnectorSdkPackageCreateService {
+	s.fileName = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageCreateService) Do(ctx context.Context) (ConnectorSdkPackageResponse, error) {
+	var response ConnectorSdkPackageResponse
+	if s.fileContent == nil {
+		return response, fmt.Errorf("missing required fileContent")
+	}
+
+	fileName := "code.zip"
+	if s.fileName != nil {
+		fileName = *s.fileName
+	}
+
+	err := s.HttpService.DoMultipart(ctx, "POST", "/connector-sdk/packages", "file", fileName, s.fileContent, nil, 201, &response)
+	return response, err
+}

--- a/connector_sdk/connector_sdk_package_create_test.go
+++ b/connector_sdk/connector_sdk_package_create_test.go
@@ -1,0 +1,38 @@
+package connectorsdk_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	testutils "github.com/fivetran/go-fivetran/test_utils"
+	"github.com/fivetran/go-fivetran/tests/mock"
+)
+
+func TestConnectorSdkPackageCreateServiceDo(t *testing.T) {
+	ftClient, mockClient := testutils.CreateTestClient()
+	handler := mockClient.When(http.MethodPost, "/v1/connector-sdk/packages").
+		ThenCall(func(req *http.Request) (*http.Response, error) {
+			contentType := req.Header.Get("Content-Type")
+			if !strings.Contains(contentType, "multipart/form-data") {
+				t.Errorf("expected multipart/form-data content type, got %s", contentType)
+			}
+			response := mock.NewResponse(req, http.StatusCreated, preparePackageDetailsResponse())
+			return response, nil
+		})
+
+	response, err := ftClient.NewConnectorSdkPackageCreate().
+		FileContent(strings.NewReader("fake-zip-content")).
+		Do(context.Background())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	interactions := mockClient.Interactions()
+	testutils.AssertEqual(t, len(interactions), 1)
+	testutils.AssertEqual(t, interactions[0].Handler, handler)
+	testutils.AssertEqual(t, handler.Interactions, 1)
+	assertPackageResponse(t, response)
+}

--- a/connector_sdk/connector_sdk_package_delete.go
+++ b/connector_sdk/connector_sdk_package_delete.go
@@ -1,0 +1,30 @@
+package connectorsdk
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fivetran/go-fivetran/common"
+	httputils "github.com/fivetran/go-fivetran/http_utils"
+)
+
+type ConnectorSdkPackageDeleteService struct {
+	httputils.HttpService
+	packageID *string
+}
+
+func (s *ConnectorSdkPackageDeleteService) PackageID(value string) *ConnectorSdkPackageDeleteService {
+	s.packageID = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageDeleteService) Do(ctx context.Context) (common.CommonResponse, error) {
+	var response common.CommonResponse
+	if s.packageID == nil {
+		return response, fmt.Errorf("missing required packageID")
+	}
+
+	url := fmt.Sprintf("/connector-sdk/packages/%v", *s.packageID)
+	err := s.HttpService.Do(ctx, "DELETE", url, nil, nil, 200, &response)
+	return response, err
+}

--- a/connector_sdk/connector_sdk_package_delete_test.go
+++ b/connector_sdk/connector_sdk_package_delete_test.go
@@ -1,0 +1,37 @@
+package connectorsdk_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	testutils "github.com/fivetran/go-fivetran/test_utils"
+	"github.com/fivetran/go-fivetran/tests/mock"
+)
+
+func TestConnectorSdkPackageDeleteServiceDo(t *testing.T) {
+	ftClient, mockClient := testutils.CreateTestClient()
+	handler := mockClient.When(http.MethodDelete, "/v1/connector-sdk/packages/happy_harmony").
+		ThenCall(func(req *http.Request) (*http.Response, error) {
+			response := mock.NewResponse(req, http.StatusOK, `{
+				"code": "Success",
+				"message": "Package has been deleted"
+			}`)
+			return response, nil
+		})
+
+	response, err := ftClient.NewConnectorSdkPackageDelete().
+		PackageID("happy_harmony").
+		Do(context.Background())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	interactions := mockClient.Interactions()
+	testutils.AssertEqual(t, len(interactions), 1)
+	testutils.AssertEqual(t, interactions[0].Handler, handler)
+	testutils.AssertEqual(t, handler.Interactions, 1)
+	testutils.AssertEqual(t, response.Code, "Success")
+	testutils.AssertEqual(t, response.Message, "Package has been deleted")
+}

--- a/connector_sdk/connector_sdk_package_details.go
+++ b/connector_sdk/connector_sdk_package_details.go
@@ -1,0 +1,29 @@
+package connectorsdk
+
+import (
+	"context"
+	"fmt"
+
+	httputils "github.com/fivetran/go-fivetran/http_utils"
+)
+
+type ConnectorSdkPackageDetailsService struct {
+	httputils.HttpService
+	packageID *string
+}
+
+func (s *ConnectorSdkPackageDetailsService) PackageID(value string) *ConnectorSdkPackageDetailsService {
+	s.packageID = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageDetailsService) Do(ctx context.Context) (ConnectorSdkPackageResponse, error) {
+	var response ConnectorSdkPackageResponse
+	if s.packageID == nil {
+		return response, fmt.Errorf("missing required packageID")
+	}
+
+	url := fmt.Sprintf("/connector-sdk/packages/%v", *s.packageID)
+	err := s.HttpService.Do(ctx, "GET", url, nil, nil, 200, &response)
+	return response, err
+}

--- a/connector_sdk/connector_sdk_package_details_test.go
+++ b/connector_sdk/connector_sdk_package_details_test.go
@@ -1,0 +1,60 @@
+package connectorsdk_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+
+	connectorsdk "github.com/fivetran/go-fivetran/connector_sdk"
+	testutils "github.com/fivetran/go-fivetran/test_utils"
+	"github.com/fivetran/go-fivetran/tests/mock"
+)
+
+func TestConnectorSdkPackageDetailsServiceDo(t *testing.T) {
+	ftClient, mockClient := testutils.CreateTestClient()
+	handler := mockClient.When(http.MethodGet, "/v1/connector-sdk/packages/happy_harmony").
+		ThenCall(func(req *http.Request) (*http.Response, error) {
+			response := mock.NewResponse(req, http.StatusOK, preparePackageDetailsResponse())
+			return response, nil
+		})
+
+	response, err := ftClient.NewConnectorSdkPackageDetails().
+		PackageID("happy_harmony").
+		Do(context.Background())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	interactions := mockClient.Interactions()
+	testutils.AssertEqual(t, len(interactions), 1)
+	testutils.AssertEqual(t, interactions[0].Handler, handler)
+	testutils.AssertEqual(t, handler.Interactions, 1)
+	assertPackageResponse(t, response)
+}
+
+func preparePackageDetailsResponse() string {
+	return fmt.Sprintf(`{
+		"code": "Success",
+		"data": {
+			"id": "happy_harmony",
+			"connection_id": "conn_123",
+			"created_by": "user_1",
+			"last_updated_by": "user_2",
+			"created_at": "2024-01-01T00:00:00.000000Z",
+			"updated_at": "2024-01-02T00:00:00.000000Z",
+			"file_sha256_hash": "abc123def456"
+		}
+	}`)
+}
+
+func assertPackageResponse(t *testing.T, response connectorsdk.ConnectorSdkPackageResponse) {
+	t.Helper()
+	testutils.AssertEqual(t, response.Code, "Success")
+	testutils.AssertEqual(t, response.Data.ID, "happy_harmony")
+	testutils.AssertEqual(t, response.Data.ConnectionID, "conn_123")
+	testutils.AssertEqual(t, response.Data.CreatedBy, "user_1")
+	testutils.AssertEqual(t, response.Data.LastUpdatedBy, "user_2")
+	testutils.AssertEqual(t, response.Data.FileSha256Hash, "abc123def456")
+}

--- a/connector_sdk/connector_sdk_package_list.go
+++ b/connector_sdk/connector_sdk_package_list.go
@@ -1,0 +1,40 @@
+package connectorsdk
+
+import (
+	"context"
+	"fmt"
+
+	httputils "github.com/fivetran/go-fivetran/http_utils"
+)
+
+type ConnectorSdkPackageListService struct {
+	httputils.HttpService
+	limit  *int
+	cursor *string
+}
+
+func (s *ConnectorSdkPackageListService) Limit(value int) *ConnectorSdkPackageListService {
+	s.limit = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageListService) Cursor(value string) *ConnectorSdkPackageListService {
+	s.cursor = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageListService) Do(ctx context.Context) (ConnectorSdkPackagesListResponse, error) {
+	var response ConnectorSdkPackagesListResponse
+	var queries map[string]string = nil
+	if s.cursor != nil || s.limit != nil {
+		queries = make(map[string]string)
+		if s.cursor != nil {
+			queries["cursor"] = *s.cursor
+		}
+		if s.limit != nil {
+			queries["limit"] = fmt.Sprintf("%v", *s.limit)
+		}
+	}
+	err := s.HttpService.Do(ctx, "GET", "/connector-sdk/packages", nil, queries, 200, &response)
+	return response, err
+}

--- a/connector_sdk/connector_sdk_package_list_test.go
+++ b/connector_sdk/connector_sdk_package_list_test.go
@@ -1,0 +1,58 @@
+package connectorsdk_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	testutils "github.com/fivetran/go-fivetran/test_utils"
+	"github.com/fivetran/go-fivetran/tests/mock"
+)
+
+func TestConnectorSdkPackageListServiceDo(t *testing.T) {
+	ftClient, mockClient := testutils.CreateTestClient()
+	handler := mockClient.When(http.MethodGet, "/v1/connector-sdk/packages").
+		ThenCall(func(req *http.Request) (*http.Response, error) {
+			testutils.AssertEqual(t, req.URL.Query().Get("cursor"), "next_page")
+			testutils.AssertEqual(t, req.URL.Query().Get("limit"), "10")
+			response := mock.NewResponse(req, http.StatusOK, preparePackageListResponse())
+			return response, nil
+		})
+
+	response, err := ftClient.NewConnectorSdkPackageList().
+		Cursor("next_page").
+		Limit(10).
+		Do(context.Background())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	interactions := mockClient.Interactions()
+	testutils.AssertEqual(t, len(interactions), 1)
+	testutils.AssertEqual(t, interactions[0].Handler, handler)
+	testutils.AssertEqual(t, handler.Interactions, 1)
+	testutils.AssertEqual(t, response.Code, "Success")
+	testutils.AssertEqual(t, len(response.Data.Items), 1)
+	testutils.AssertEqual(t, response.Data.Items[0].ID, "happy_harmony")
+	testutils.AssertEqual(t, response.Data.Items[0].FileSha256Hash, "abc123def456")
+	testutils.AssertEqual(t, response.Data.NextCursor, "cursor_value")
+}
+
+func preparePackageListResponse() string {
+	return `{
+		"code": "Success",
+		"data": {
+			"items": [{
+				"id": "happy_harmony",
+				"connection_id": "conn_123",
+				"created_by": "user_1",
+				"last_updated_by": "user_2",
+				"created_at": "2024-01-01T00:00:00.000000Z",
+				"updated_at": "2024-01-02T00:00:00.000000Z",
+				"file_sha256_hash": "abc123def456"
+			}],
+			"next_cursor": "cursor_value"
+		}
+	}`
+}

--- a/connector_sdk/connector_sdk_package_update.go
+++ b/connector_sdk/connector_sdk_package_update.go
@@ -1,0 +1,50 @@
+package connectorsdk
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	httputils "github.com/fivetran/go-fivetran/http_utils"
+)
+
+type ConnectorSdkPackageUpdateService struct {
+	httputils.HttpService
+	packageID   *string
+	fileContent io.Reader
+	fileName    *string
+}
+
+func (s *ConnectorSdkPackageUpdateService) PackageID(value string) *ConnectorSdkPackageUpdateService {
+	s.packageID = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageUpdateService) FileContent(value io.Reader) *ConnectorSdkPackageUpdateService {
+	s.fileContent = value
+	return s
+}
+
+func (s *ConnectorSdkPackageUpdateService) FileName(value string) *ConnectorSdkPackageUpdateService {
+	s.fileName = &value
+	return s
+}
+
+func (s *ConnectorSdkPackageUpdateService) Do(ctx context.Context) (ConnectorSdkPackageResponse, error) {
+	var response ConnectorSdkPackageResponse
+	if s.packageID == nil {
+		return response, fmt.Errorf("missing required packageID")
+	}
+	if s.fileContent == nil {
+		return response, fmt.Errorf("missing required fileContent")
+	}
+
+	fileName := "code.zip"
+	if s.fileName != nil {
+		fileName = *s.fileName
+	}
+
+	url := fmt.Sprintf("/connector-sdk/packages/%v", *s.packageID)
+	err := s.HttpService.DoMultipart(ctx, "PATCH", url, "file", fileName, s.fileContent, nil, 200, &response)
+	return response, err
+}

--- a/connector_sdk/connector_sdk_package_update_test.go
+++ b/connector_sdk/connector_sdk_package_update_test.go
@@ -1,0 +1,39 @@
+package connectorsdk_test
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+
+	testutils "github.com/fivetran/go-fivetran/test_utils"
+	"github.com/fivetran/go-fivetran/tests/mock"
+)
+
+func TestConnectorSdkPackageUpdateServiceDo(t *testing.T) {
+	ftClient, mockClient := testutils.CreateTestClient()
+	handler := mockClient.When(http.MethodPatch, "/v1/connector-sdk/packages/happy_harmony").
+		ThenCall(func(req *http.Request) (*http.Response, error) {
+			contentType := req.Header.Get("Content-Type")
+			if !strings.Contains(contentType, "multipart/form-data") {
+				t.Errorf("expected multipart/form-data content type, got %s", contentType)
+			}
+			response := mock.NewResponse(req, http.StatusOK, preparePackageDetailsResponse())
+			return response, nil
+		})
+
+	response, err := ftClient.NewConnectorSdkPackageUpdate().
+		PackageID("happy_harmony").
+		FileContent(strings.NewReader("fake-zip-content-updated")).
+		Do(context.Background())
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	interactions := mockClient.Interactions()
+	testutils.AssertEqual(t, len(interactions), 1)
+	testutils.AssertEqual(t, interactions[0].Handler, handler)
+	testutils.AssertEqual(t, handler.Interactions, 1)
+	assertPackageResponse(t, response)
+}

--- a/http_utils/http_service_multipart.go
+++ b/http_utils/http_service_multipart.go
@@ -1,0 +1,65 @@
+package httputils
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+)
+
+func (s HttpService) DoMultipart(
+	ctx context.Context,
+	method,
+	url string,
+	fieldName string,
+	fileName string,
+	fileContent io.Reader,
+	queries map[string]string,
+	expectedStatus int,
+	response any) error {
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+
+	part, err := writer.CreateFormFile(fieldName, fileName)
+	if err != nil {
+		return fmt.Errorf("failed to create form file: %w", err)
+	}
+
+	if _, err := io.Copy(part, fileContent); err != nil {
+		return fmt.Errorf("failed to write file content: %w", err)
+	}
+
+	if err := writer.Close(); err != nil {
+		return fmt.Errorf("failed to close multipart writer: %w", err)
+	}
+
+	s.CommonHeaders["Content-Type"] = writer.FormDataContentType()
+
+	r := Request{
+		Method:           method,
+		Url:              s.BaseUrl + url,
+		Body:             buf.Bytes(),
+		Queries:          queries,
+		Headers:          s.CommonHeaders,
+		Client:           s.Client,
+		HandleRateLimits: s.HandleRateLimits,
+		MaxRetryAttempts: s.MaxRetryAttempts,
+	}
+
+	respBody, respStatus, err := r.Do(ctx)
+	if err != nil {
+		return err
+	}
+
+	if err := json.Unmarshal(respBody, &response); err != nil {
+		return err
+	}
+
+	if respStatus != expectedStatus {
+		return fmt.Errorf("status code: %v; expected: %v", respStatus, expectedStatus)
+	}
+	return nil
+}


### PR DESCRIPTION
- Create connector_sdk module with full package CRUD: Get, List, Create, Update, Delete
- Add ConnectorSdkPackageData type with file_sha256_hash field
- Add DoMultipart() to HttpService for multipart/form-data uploads (Create/Update)
- List supports cursor and limit pagination params
- Register all 5 services on Client
- Add unit tests for all operations including multipart content-type verification