### PR TITLE
Add RunSetupTests, TrustCertificates, TrustFingerprints to DetailsRes…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.6...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.7...HEAD)
+
+## [1.3.7](https://github.com/fivetran/go-fivetran/compare/v1.3.6...v1.3.7)
+
+## Added
+- `RunSetupTests`, `TrustCertificates`, and `TrustFingerprints` fields to `DetailsResponseDataCommon` for correct deserialization of connection GET/create responses.
 
 ## [1.3.6](https://github.com/fivetran/go-fivetran/compare/v1.3.5...v1.3.6)
 

--- a/connections/common_types.go
+++ b/connections/common_types.go
@@ -36,6 +36,9 @@ type DetailsResponseDataCommon struct {
     NetworkingMethod        string             `json:"networking_method"`
     DataDelaySensitivity    string             `json:"data_delay_sensitivity"`
     DataDelayThreshold      *int               `json:"data_delay_threshold"`
+    RunSetupTests           *bool              `json:"run_setup_tests,omitempty"`
+    TrustCertificates       *bool              `json:"trust_certificates,omitempty"`
+    TrustFingerprints       *bool              `json:"trust_fingerprints,omitempty"`
     Schedule                *ConnectorSchedule `json:"schedule,omitempty"`
     Status                  StatusResponse     `json:"status"`
 }


### PR DESCRIPTION
…ponseDataCommon

Fields were returned by the API but not deserialized, causing the terraform-provider-fivetran connection_v2 resource to see nil where the API returned false, producing post-apply inconsistency errors.