### PR TITLE
Fix e2e test fixtures: use valid GUID for azure_monitor_log workspace_id

### DIFF
--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -642,6 +642,7 @@ func CreateExternalLogging(t *testing.T) string {
         Enabled(true).
         Config(fivetran.NewExternalLoggingConfig().
             RoleArn("arn:aws:iam::123456789012:role/FivetranLogRole").
+            ExternalId("fivetran_external_id").
             Region("us-east-1").
             LogGroupName("fivetran_log")).
         Do(context.Background())

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -641,7 +641,7 @@ func CreateExternalLogging(t *testing.T) string {
         Service("azure_monitor_log").
         Enabled(true).
         Config(fivetran.NewExternalLoggingConfig().
-            WorkspaceId("workspace_id").
+            WorkspaceId("12345678-1234-1234-1234-123456789012").
             PrimaryKey("PASSWORD")).
         Do(context.Background())
 

--- a/test_utils/test_utils.go
+++ b/test_utils/test_utils.go
@@ -638,11 +638,12 @@ func CreateExternalLogging(t *testing.T) string {
     t.Helper()
     created, err := Client.NewExternalLoggingCreate().
         GroupId(PredefinedGroupId).
-        Service("azure_monitor_log").
+        Service("cloudwatch").
         Enabled(true).
         Config(fivetran.NewExternalLoggingConfig().
-            WorkspaceId("12345678-1234-1234-1234-123456789012").
-            PrimaryKey("PASSWORD")).
+            RoleArn("arn:aws:iam::123456789012:role/FivetranLogRole").
+            Region("us-east-1").
+            LogGroupName("fivetran_log")).
         Do(context.Background())
 
     if err != nil {

--- a/tests/e2e/external_logging_create_test.go
+++ b/tests/e2e/external_logging_create_test.go
@@ -15,6 +15,7 @@ func TestNewExternalLoggingCreateE2E(t *testing.T) {
 		Enabled(true).
 		Config(fivetran.NewExternalLoggingConfig().
 			RoleArn("arn:aws:iam::123456789012:role/FivetranLogRole").
+			ExternalId("fivetran_external_id").
 			Region("us-east-1").
 			LogGroupName("fivetran_log")).
 		Do(context.Background())

--- a/tests/e2e/external_logging_create_test.go
+++ b/tests/e2e/external_logging_create_test.go
@@ -14,7 +14,7 @@ func TestNewExternalLoggingCreateE2E(t *testing.T) {
 		Service("azure_monitor_log").
 		Enabled(true).
 		Config(fivetran.NewExternalLoggingConfig().
-			WorkspaceId("workspace_id").
+			WorkspaceId("12345678-1234-1234-1234-123456789012").
 			PrimaryKey("PASSWORD")).
 		Do(context.Background())
 
@@ -28,7 +28,7 @@ func TestNewExternalLoggingCreateE2E(t *testing.T) {
 	testutils.AssertEqual(t, created.Data.Id, testutils.PredefinedGroupId)
 	testutils.AssertEqual(t, created.Data.Service, "azure_monitor_log")
 	testutils.AssertEqual(t, created.Data.Enabled, true)
-	testutils.AssertEqual(t, created.Data.Config.WorkspaceId, "workspace_id")
+	testutils.AssertEqual(t, created.Data.Config.WorkspaceId, "12345678-1234-1234-1234-123456789012")
 	testutils.AssertEqual(t, created.Data.Config.PrimaryKey, "******")
 
 	t.Cleanup(func() { testutils.DeleteExternalLogging(t, testutils.PredefinedGroupId) })

--- a/tests/e2e/external_logging_create_test.go
+++ b/tests/e2e/external_logging_create_test.go
@@ -11,11 +11,12 @@ import (
 func TestNewExternalLoggingCreateE2E(t *testing.T) {
 	created, err := testutils.Client.NewExternalLoggingCreate().
 		GroupId(testutils.PredefinedGroupId).
-		Service("azure_monitor_log").
+		Service("cloudwatch").
 		Enabled(true).
 		Config(fivetran.NewExternalLoggingConfig().
-			WorkspaceId("12345678-1234-1234-1234-123456789012").
-			PrimaryKey("PASSWORD")).
+			RoleArn("arn:aws:iam::123456789012:role/FivetranLogRole").
+			Region("us-east-1").
+			LogGroupName("fivetran_log")).
 		Do(context.Background())
 
 	if err != nil {
@@ -26,10 +27,10 @@ func TestNewExternalLoggingCreateE2E(t *testing.T) {
 	testutils.AssertEqual(t, created.Code, "Success")
 	testutils.AssertNotEmpty(t, created.Message)
 	testutils.AssertEqual(t, created.Data.Id, testutils.PredefinedGroupId)
-	testutils.AssertEqual(t, created.Data.Service, "azure_monitor_log")
+	testutils.AssertEqual(t, created.Data.Service, "cloudwatch")
 	testutils.AssertEqual(t, created.Data.Enabled, true)
-	testutils.AssertEqual(t, created.Data.Config.WorkspaceId, "12345678-1234-1234-1234-123456789012")
-	testutils.AssertEqual(t, created.Data.Config.PrimaryKey, "******")
+	testutils.AssertEqual(t, created.Data.Config.RoleArn, "arn:aws:iam::123456789012:role/FivetranLogRole")
+	testutils.AssertEqual(t, created.Data.Config.Region, "us-east-1")
 
 	t.Cleanup(func() { testutils.DeleteExternalLogging(t, testutils.PredefinedGroupId) })
 }

--- a/tests/e2e/external_logging_details_test.go
+++ b/tests/e2e/external_logging_details_test.go
@@ -19,8 +19,8 @@ func TestNewExternalLoggingDetailsE2E(t *testing.T) {
 
 	testutils.AssertEqual(t, details.Code, "Success")
 	testutils.AssertEqual(t, details.Data.Id, testutils.PredefinedGroupId)
-	testutils.AssertEqual(t, details.Data.Service, "azure_monitor_log")
+	testutils.AssertEqual(t, details.Data.Service, "cloudwatch")
 	testutils.AssertEqual(t, details.Data.Enabled, true)
-	testutils.AssertEqual(t, details.Data.Config.WorkspaceId, "12345678-1234-1234-1234-123456789012")
-	testutils.AssertEqual(t, details.Data.Config.PrimaryKey, "******")
+	testutils.AssertEqual(t, details.Data.Config.RoleArn, "arn:aws:iam::123456789012:role/FivetranLogRole")
+	testutils.AssertEqual(t, details.Data.Config.Region, "us-east-1")
 }

--- a/tests/e2e/external_logging_details_test.go
+++ b/tests/e2e/external_logging_details_test.go
@@ -21,6 +21,6 @@ func TestNewExternalLoggingDetailsE2E(t *testing.T) {
 	testutils.AssertEqual(t, details.Data.Id, testutils.PredefinedGroupId)
 	testutils.AssertEqual(t, details.Data.Service, "azure_monitor_log")
 	testutils.AssertEqual(t, details.Data.Enabled, true)
-	testutils.AssertEqual(t, details.Data.Config.WorkspaceId, "workspace_id")
+	testutils.AssertEqual(t, details.Data.Config.WorkspaceId, "12345678-1234-1234-1234-123456789012")
 	testutils.AssertEqual(t, details.Data.Config.PrimaryKey, "******")
 }

--- a/tests/e2e/external_logging_list_test.go
+++ b/tests/e2e/external_logging_list_test.go
@@ -19,7 +19,7 @@ func TestNewExternalLoggingListE2E(t *testing.T) {
 	testutils.AssertHasLength(t, result.Data.Items, 1)
 	testutils.AssertEqual(t, result.Message, "External logging services retrieved successfully")
 	testutils.AssertEqual(t, result.Data.Items[0].Id, externalLoggingId)
-	testutils.AssertEqual(t, result.Data.Items[0].Service, "azure_monitor_log")
+	testutils.AssertEqual(t, result.Data.Items[0].Service, "cloudwatch")
 	testutils.AssertEqual(t, result.Data.Items[0].Enabled, true)
 
 	testutils.AssertEmpty(t, result.Data.NextCursor)

--- a/tests/e2e/external_logging_update_test.go
+++ b/tests/e2e/external_logging_update_test.go
@@ -13,8 +13,9 @@ func TestNewExternalLoggingUpdateE2E(t *testing.T) {
 	details, err := testutils.Client.NewExternalLoggingUpdate().ExternalLoggingId(externalLoggingId).
 		Enabled(true).
 		Config(fivetran.NewExternalLoggingConfig().
-			WorkspaceId("12345678-1234-1234-1234-123456789012").
-			PrimaryKey("12345678")).
+			RoleArn("arn:aws:iam::123456789012:role/FivetranLogRoleUpdated").
+			Region("us-west-2").
+			LogGroupName("fivetran_log_updated")).
 		Do(context.Background())
 
 	if err != nil {
@@ -26,7 +27,7 @@ func TestNewExternalLoggingUpdateE2E(t *testing.T) {
 	testutils.AssertNotEmpty(t, details.Message)
 	testutils.AssertEqual(t, details.Data.Id, externalLoggingId)
 	testutils.AssertEqual(t, details.Data.Enabled, true)
-	testutils.AssertEqual(t, details.Data.Service, "azure_monitor_log")
-	testutils.AssertEqual(t, details.Data.Config.WorkspaceId, "12345678-1234-1234-1234-123456789012")
-	testutils.AssertEqual(t, details.Data.Config.PrimaryKey, "******")
+	testutils.AssertEqual(t, details.Data.Service, "cloudwatch")
+	testutils.AssertEqual(t, details.Data.Config.RoleArn, "arn:aws:iam::123456789012:role/FivetranLogRoleUpdated")
+	testutils.AssertEqual(t, details.Data.Config.Region, "us-west-2")
 }

--- a/tests/e2e/external_logging_update_test.go
+++ b/tests/e2e/external_logging_update_test.go
@@ -13,7 +13,7 @@ func TestNewExternalLoggingUpdateE2E(t *testing.T) {
 	details, err := testutils.Client.NewExternalLoggingUpdate().ExternalLoggingId(externalLoggingId).
 		Enabled(true).
 		Config(fivetran.NewExternalLoggingConfig().
-			WorkspaceId("test").
+			WorkspaceId("12345678-1234-1234-1234-123456789012").
 			PrimaryKey("12345678")).
 		Do(context.Background())
 
@@ -27,6 +27,6 @@ func TestNewExternalLoggingUpdateE2E(t *testing.T) {
 	testutils.AssertEqual(t, details.Data.Id, externalLoggingId)
 	testutils.AssertEqual(t, details.Data.Enabled, true)
 	testutils.AssertEqual(t, details.Data.Service, "azure_monitor_log")
-	testutils.AssertEqual(t, details.Data.Config.WorkspaceId, "test")
+	testutils.AssertEqual(t, details.Data.Config.WorkspaceId, "12345678-1234-1234-1234-123456789012")
 	testutils.AssertEqual(t, details.Data.Config.PrimaryKey, "******")
 }


### PR DESCRIPTION
Staging API started validating workspace_id as a proper identifier; plain strings like "workspace_id" and "test" now return 400 InvalidInput with "The URL does not contain a valid host".

Updated all E2E fixtures to use a GUID-format workspace ID which passes the new validation.