### PR TITLE
Add ParentTable field to ConnectionSchemaConfigTableResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.7...HEAD)
+## [Unreleased](https://github.com/fivetran/go-fivetran/compare/v1.3.9...HEAD)
+
+## [1.3.9](https://github.com/fivetran/go-fivetran/compare/v1.3.8...v1.3.9)
+
+## Added
+- `ParentTable` field to `ConnectionSchemaConfigTableResponse` for deserializing core-table/child-table grouping from connection schema config responses.
+
+## [1.3.8](https://github.com/fivetran/go-fivetran/compare/v1.3.7...v1.3.8)
 
 ## Added
 - Connection create/update/details support for Terraform-managed connection v2 fields:

--- a/client.go
+++ b/client.go
@@ -40,7 +40,7 @@ const defaultBaseURL = "https://api.fivetran.com/v1"
 const restAPIv2 = "application/json;version=2"
 
 // WARNING: Update Agent version on each release!
-const defaultUserAgent = "Go-Fivetran/1.3.8"
+const defaultUserAgent = "Go-Fivetran/1.3.9"
 
 // New receives API Key and API Secret, and returns a new Client with the
 // default HTTP client

--- a/connections/connection_details_test.go
+++ b/connections/connection_details_test.go
@@ -72,7 +72,7 @@ func TestCustomConnectionDetailsWithUserAgentSuffixMock(t *testing.T) {
 	ftClient.CustomUserAgent("terraform-provider-fivetran/1.9.37")
 	handler := mockClient.When(http.MethodGet, "/v1/connections/connection_id").ThenCall(
 		func(req *http.Request) (*http.Response, error) {
-			testutils.AssertEqual(t, req.Header.Get("User-Agent"), "Go-Fivetran/1.3.8 terraform-provider-fivetran/1.9.37 fivetran_connection_v2")
+			testutils.AssertEqual(t, req.Header.Get("User-Agent"), "Go-Fivetran/1.3.9 terraform-provider-fivetran/1.9.37 fivetran_connection_v2")
 			response := mock.NewResponse(req, http.StatusOK, prepareConnectionDetailsResponse())
 			return response, nil
 		})

--- a/connections/connection_schema_config_table.go
+++ b/connections/connection_schema_config_table.go
@@ -18,6 +18,7 @@ type ConnectionSchemaConfigTableResponse struct {
 	SyncMode              *string                                         `json:"sync_mode"`
 	Columns               map[string]*ConnectionSchemaConfigColumnResponse `json:"columns"`
 	SupportsColumnsConfig *bool                                           `json:"supports_columns_config"`
+	ParentTable           *string                                         `json:"parent_table"`
 	EnabledPatchSettings  struct {
 		Allowed    *bool   `json:"allowed"`
 		ReasonCode *string `json:"reason_code"`

--- a/http_utils/http_service_test.go
+++ b/http_utils/http_service_test.go
@@ -26,7 +26,7 @@ func TestDoWithUserAgentSuffixAppendsSuffixWithoutMutatingCommonHeaders(t *testi
 		BaseUrl: "https://api.example.com/v1",
 		CommonHeaders: map[string]string{
 			"Authorization": "Basic token",
-			"User-Agent":    "Go-Fivetran/1.3.8 terraform-provider-fivetran/1.9.37",
+			"User-Agent":    "Go-Fivetran/1.3.9 terraform-provider-fivetran/1.9.37",
 		},
 		Client: client,
 	}
@@ -46,10 +46,10 @@ func TestDoWithUserAgentSuffixAppendsSuffixWithoutMutatingCommonHeaders(t *testi
 		t.Fatalf("DoWithUserAgentSuffix returned error: %v", err)
 	}
 
-	if got, want := client.request.Header.Get("User-Agent"), "Go-Fivetran/1.3.8 terraform-provider-fivetran/1.9.37 fivetran_connection_v2"; got != want {
+	if got, want := client.request.Header.Get("User-Agent"), "Go-Fivetran/1.3.9 terraform-provider-fivetran/1.9.37 fivetran_connection_v2"; got != want {
 		t.Fatalf("request User-Agent = %q, want %q", got, want)
 	}
-	if got, want := service.CommonHeaders["User-Agent"], "Go-Fivetran/1.3.8 terraform-provider-fivetran/1.9.37"; got != want {
+	if got, want := service.CommonHeaders["User-Agent"], "Go-Fivetran/1.3.9 terraform-provider-fivetran/1.9.37"; got != want {
 		t.Fatalf("common User-Agent = %q, want %q", got, want)
 	}
 }

--- a/metadata/metadata_details_test.go
+++ b/metadata/metadata_details_test.go
@@ -46,7 +46,7 @@ func TestMetadataDetailsServiceDoWithUserAgentSuffix(t *testing.T) {
 	ftClient.CustomUserAgent("terraform-provider-fivetran/1.9.37")
 	handler := mockClient.When(http.MethodGet, "/v1/metadata/connector-types/google_ads").
 		ThenCall(func(req *http.Request) (*http.Response, error) {
-			testutils.AssertEqual(t, req.Header.Get("User-Agent"), "Go-Fivetran/1.3.8 terraform-provider-fivetran/1.9.37 fivetran_connection_v2")
+			testutils.AssertEqual(t, req.Header.Get("User-Agent"), "Go-Fivetran/1.3.9 terraform-provider-fivetran/1.9.37 fivetran_connection_v2")
 			response := mock.NewResponse(req, http.StatusOK, prepareMetadataDetailsResponse())
 			return response, nil
 		})


### PR DESCRIPTION
Mirrors the new parent_table field on the schema config API response, so the Terraform provider can deserialize core-table/child-table grouping instead of losing it on every refresh.

Prepares the CHANGELOG and default User-Agent version for the v1.3.9 release: backfills the missing v1.3.8 section (tagged but never documented) and bumps 1.3.8 -> 1.3.9 for this change.